### PR TITLE
Make header clickable

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import { Container, Stack } from '@chakra-ui/react';
+import { Link } from 'gatsby';
 import type { FunctionComponent } from 'react';
 
 import { Logo } from './Logo';
@@ -15,7 +16,9 @@ export const Header: FunctionComponent = () => (
     marginBottom="20"
   >
     <Stack direction="row" height="7" align="center">
-      <Logo />
+      <Link to="/">
+        <Logo />
+      </Link>
     </Stack>
   </Container>
 );


### PR DESCRIPTION
This is a small UX improvement. It makes the logo in the header clickable (to navigate back to `/`).