### PR TITLE
Remove line numbers from translation file

### DIFF
--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -1,9 +1,10 @@
 import type { LinguiConfig } from '@lingui/conf';
+import { formatter } from '@lingui/format-po';
 
 const config: LinguiConfig = {
   compileNamespace: 'es',
   locales: ['en'],
-  format: 'po',
+  format: formatter({ lineNumbers: false }),
   catalogs: [
     {
       path: '<rootDir>/src/locales/{locale}/messages',

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@lavamoat/preinstall-always-fail": "^1.0.0",
     "@lingui/cli": "^4.4.2",
     "@lingui/conf": "^4.4.2",
+    "@lingui/format-po": "^4.4.2",
     "@metamask/eslint-config": "^12.0.0",
     "@metamask/eslint-config-browser": "^12.0.0",
     "@metamask/eslint-config-jest": "^12.0.0",

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,95 +13,95 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/Footer.tsx:31
+#: src/components/Footer.tsx
 msgid "©{0} MetaMask. All rights reserved."
 msgstr ""
 
-#: src/components/InstallSnapButton.tsx:80
+#: src/components/InstallSnapButton.tsx
 msgid "Add to MetaMask"
 msgstr ""
 
-#: src/pages/snap/{Snap.slug}.tsx:108
+#: src/pages/snap/{Snap.slug}.tsx
 msgid "Audit"
 msgstr ""
 
-#: src/pages/snap/{Snap.slug}.tsx:81
+#: src/pages/snap/{Snap.slug}.tsx
 msgid "Category"
 msgstr ""
 
-#: src/components/Icon.tsx:16
+#: src/components/Icon.tsx
 msgid "Check"
 msgstr ""
 
-#: src/pages/index.tsx:61
+#: src/pages/index.tsx
 msgid "Community Snaps"
 msgstr ""
 
-#: src/components/PostInstallModal.tsx:44
+#: src/components/PostInstallModal.tsx
 msgid "Continue to {name}'s website to get started with this snap."
 msgstr ""
 
-#: src/pages/snap/{Snap.slug}.tsx:124
+#: src/pages/snap/{Snap.slug}.tsx
 msgid "Description by <0>{name}</0>"
 msgstr ""
 
-#: src/pages/snap/{Snap.slug}.tsx:92
+#: src/pages/snap/{Snap.slug}.tsx
 msgid "Developer"
 msgstr ""
 
-#: src/pages/index.tsx:64
+#: src/pages/index.tsx
 msgid "Discover snaps to customize your web3 experience via our official directory. <0>Read more</0> and <1>FAQ</1>."
 msgstr ""
 
-#: src/components/Icon.tsx:32
-#: src/components/Icon.tsx:36
+#: src/components/Icon.tsx
+#: src/components/Icon.tsx
 msgid "External Link"
 msgstr ""
 
-#: src/components/PostInstallModal.tsx:41
+#: src/components/PostInstallModal.tsx
 msgid "Installation complete"
 msgstr ""
 
-#: src/components/InstallSnapButton.tsx:69
+#: src/components/InstallSnapButton.tsx
 msgid "Installed"
 msgstr ""
 
-#: src/components/Icon.tsx:20
+#: src/components/Icon.tsx
 msgid "MetaMask"
 msgstr ""
 
-#: src/components/Footer.tsx:37
+#: src/components/Footer.tsx
 msgid "Privacy Policy"
 msgstr ""
 
-#: src/components/Icon.tsx:24
+#: src/components/Icon.tsx
 msgid "Search"
 msgstr ""
 
-#: src/pages/index.tsx:86
+#: src/pages/index.tsx
 msgid "Search snaps..."
 msgstr ""
 
-#: src/components/Icon.tsx:28
+#: src/components/Icon.tsx
 msgid "Snap"
 msgstr ""
 
-#: src/pages/snap/{Snap.slug}.tsx:102
+#: src/pages/snap/{Snap.slug}.tsx
 msgid "Source Code"
 msgstr ""
 
-#: src/components/Footer.tsx:20
+#: src/components/Footer.tsx
 msgid "Start exploring blockchain applications in seconds. Trusted by over 30 million users worldwide."
 msgstr ""
 
-#: src/pages/404.tsx:14
+#: src/pages/404.tsx
 msgid "These are not the droids you are looking for."
 msgstr ""
 
-#: src/pages/snap/{Snap.slug}.tsx:89
+#: src/pages/snap/{Snap.slug}.tsx
 msgid "Version"
 msgstr ""
 
-#: src/pages/snap/{Snap.slug}.tsx:65
+#: src/pages/snap/{Snap.slug}.tsx
 msgid "Website"
 msgstr ""

--- a/yarn.lock
+++ b/yarn.lock
@@ -4117,7 +4117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lingui/format-po@npm:4.4.2":
+"@lingui/format-po@npm:4.4.2, @lingui/format-po@npm:^4.4.2":
   version: 4.4.2
   resolution: "@lingui/format-po@npm:4.4.2"
   dependencies:
@@ -18100,6 +18100,7 @@ __metadata:
     "@lingui/cli": ^4.4.2
     "@lingui/conf": ^4.4.2
     "@lingui/core": ^4.4.2
+    "@lingui/format-po": ^4.4.2
     "@lingui/macro": ^4.4.2
     "@lingui/react": ^4.4.2
     "@metamask/eslint-config": ^12.0.0


### PR DESCRIPTION
The line numbers were causing merge conflicts. The file should be enough to know where a message is used.