### PR TITLE
Always update cache in CI

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -35,7 +35,9 @@ jobs:
         with:
           path: |
             .cache/npm
-          key: npm-tarball-cache
+          key: npm-tarballs-${{ github.run_id }}
+          restore-keys: |
+            npm-tarballs
       - run: yarn --immutable --immutable-cache
       - name: Extract translations
         run: yarn lang:extract


### PR DESCRIPTION
`@actions/cache` does not update the cache by default if there was a cache hit. By using a unique key, but a non-unique restore key, we can make it always update the cache.