### PR TITLE
Add UI improvements for medium screens on a Snap info page

### DIFF
--- a/src/components/SnapData.tsx
+++ b/src/components/SnapData.tsx
@@ -10,7 +10,10 @@ export const SnapData: FunctionComponent<SnapDataProps> = ({
   label,
   value,
 }) => (
-  <Flex flexDirection="column">
+  <Flex
+    flexDirection="column"
+    minWidth={{ base: 'auto', md: '220px', lg: 'auto' }}
+  >
     <Text color="gray.muted" fontFamily="custom" textTransform="uppercase">
       {label}
     </Text>

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -122,6 +122,11 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
               }
             />
           )}
+          {
+            // An empty Box taking full width will divide elements in two rows
+            // only on medium size screens while keeping the full flex
+            // system for every screen.
+          }
           <Box
             display={{ base: 'none', md: 'flex', lg: 'none' }}
             flexBasis="100%"

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -98,7 +98,8 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
         <Flex
           justifyContent={{ base: 'center', md: 'space-between' }}
           flexDirection={{ base: 'column', md: 'row' }}
-          rowGap={{ base: 4, md: 0 }}
+          flexWrap={{ base: 'nowrap', md: 'wrap', lg: 'nowrap' }}
+          rowGap={{ base: 4, lg: 0 }}
         >
           {data.snap.category && (
             <SnapData
@@ -121,6 +122,11 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
               }
             />
           )}
+          <Box
+            display={{ base: 'none', md: 'flex', lg: 'none' }}
+            flexBasis="100%"
+            height={0}
+          ></Box>
           {data.snap.sourceCode && (
             <SnapData
               label={t`Source Code`}

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -131,7 +131,7 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
             display={{ base: 'none', md: 'flex', lg: 'none' }}
             flexBasis="100%"
             height={0}
-          ></Box>
+          />
           {data.snap.sourceCode && (
             <SnapData
               label={t`Source Code`}


### PR DESCRIPTION
This PR will add UI optimizations so the information on the Snap page can be readable on medium size screens.

## After
![Screenshot 2023-09-08 at 16 16 15](https://github.com/MetaMask/snaps-directory/assets/13301024/2f82350c-a288-46c8-8131-6002890819e4)

## Before
![image](https://github.com/MetaMask/snaps-directory/assets/13301024/2281369f-24d0-462f-b7d2-c83d9d9302d8)
