### PR TITLE
Fix installation button responsiveness

### DIFF
--- a/src/components/InstallSnapButton.tsx
+++ b/src/components/InstallSnapButton.tsx
@@ -73,6 +73,7 @@ export const InstallSnapButton: FunctionComponent<InstallSnapButtonProps> = ({
           leftIcon={<Icon icon="check" width="20px" />}
           variant="primary"
           isDisabled={true}
+          width={{ base: '100%', md: 'auto' }}
         >
           <Trans>Installed</Trans>
         </Button>

--- a/src/components/InstallUnsupported.tsx
+++ b/src/components/InstallUnsupported.tsx
@@ -22,6 +22,7 @@ export const InstallUnsupported: FunctionComponent = () => {
       leftIcon={<Icon icon="metamask" width="20px" />}
       variant="primary"
       onClick={onOpen}
+      width={{ base: '100%', md: 'auto' }}
     >
       <Trans>Add to MetaMask</Trans>
     </Button>


### PR DESCRIPTION
The button is duplicated, but not all of them had the same styling applied to them.

We should find a better way to do this.