### PR TITLE
Add workflow for redeploying the website

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -6,6 +6,9 @@ on:
       destination_dir:
         required: true
         type: string
+      ref:
+        required: false
+        type: string
 
 jobs:
   publish-site-to-gh-pages:
@@ -20,6 +23,8 @@ jobs:
         run: exit 1
       - name: Checkout the repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -23,9 +23,6 @@ on:
         type: string
         description: 'The Slack username to use.'
         default: 'MetaMask bot'
-    secrets:
-      SLACK_WEBHOOK_URL:
-        required: false
 
 jobs:
   get-release-tag:

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -1,0 +1,110 @@
+name: Republish release
+
+on:
+  workflow_dispatch:
+    inputs:
+      slack-channel:
+        required: false
+        type: string
+        description: 'The Slack channel to post to.'
+        default: 'metamask-dev'
+      slack-icon-url:
+        required: false
+        type: string
+        description: 'The Slack icon URL to use.'
+        default: 'https://raw.githubusercontent.com/MetaMask/action-npm-publish/main/robo.png'
+      slack-subteam:
+        required: false
+        type: string
+        description: 'The Slack subteam to mention.'
+        default: 'S042S7RE4AE' # @metamask-npm-publishers
+      slack-username:
+        required: false
+        type: string
+        description: 'The Slack username to use.'
+        default: 'MetaMask bot'
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: false
+
+jobs:
+  get-release-tag:
+    name: Get release tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.get-release-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get release tag
+        id: get-release-tag
+        run: |
+          RELEASE_TAG=$(git describe --tags --abbrev=0)
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+  announce-release:
+    name: Announce release
+    runs-on: ubuntu-latest
+    needs:
+      - get-release-tag
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.get-release-tag.outputs.tag }}
+      - id: name-version
+        name: Get Slack name and version
+        shell: bash
+        if: inputs.slack-subteam != ''
+        run: |
+          NAME_VERSION_TEXT=$(jq --raw-output '.name + "@" + .version' package.json )
+          NAME_VERSION_TEXT_STRIPPED="${NAME_VERSION_TEXT#@}"
+          echo "NAME_VERSION=$NAME_VERSION_TEXT_STRIPPED" >> "$GITHUB_OUTPUT"
+      - id: final-text
+        name: Get Slack final text
+        shell: bash
+        if: inputs.slack-subteam != ''
+        run: |
+          DEFAULT_TEXT="\`${{ steps.name-version.outputs.NAME_VERSION }}\` is awaiting redeployment :rocket: \n <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/|→ Click here to review deployment>"
+          SUBTEAM_TEXT="${{ inputs.slack-subteam }}"
+          FINAL_TEXT="$DEFAULT_TEXT"
+          if [[ ! "$SUBTEAM_TEXT" == "" ]]; then
+            FINAL_TEXT="<!subteam^$SUBTEAM_TEXT> $DEFAULT_TEXT"
+          fi
+          echo "FINAL_TEXT=$FINAL_TEXT" >> "$GITHUB_OUTPUT"
+      - name: Post to a Slack channel
+        if: inputs.slack-subteam != ''
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
+        with:
+          payload: |
+            {
+              "text": "${{ steps.final-text.outputs.FINAL_TEXT }}",
+              "icon_url": "${{ inputs.slack-icon-url }}",
+              "username": "${{ inputs.slack-username }}",
+              "channel": "#${{ inputs.slack-channel }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  # This is a dummy job that is used to require approval before publishing the
+  # release. GitHub does not allow setting environments on workflow calls, so
+  # we need to use a dummy job to configure the environment.
+  publish-release:
+    name: Publish release
+    environment: publish
+    runs-on: ubuntu-latest
+    needs:
+      - announce-release
+    steps:
+      - run: exit 0
+
+  publish-release-to-gh-pages:
+    name: Publish site to `gh-pages`
+    needs:
+      - get-release-tag
+      - publish-release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-site.yml
+    with:
+      destination_dir: .
+      ref: ${{ needs.get-release-tag.outputs.tag }}


### PR DESCRIPTION
When the registry is updated, we want to be able to redeploy the website without having to cut a release. I've added a new workflow which can be triggered through the GitHub API (or manually), and uses the latest tag to redeploy the website.