### PR TITLE
Add fetch-depth: 0 to fetch tags

### DIFF
--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -32,6 +32,8 @@ jobs:
       tag: ${{ steps.get-release-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Get release tag
         id: get-release-tag
         run: |


### PR DESCRIPTION
`actions/checkout` only fetches a single commit by default. In order to get tags we need to set `fetch-depth: 0`.