### PR TITLE
Add skeleton loader fallback

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,21 @@
+import { Flex } from '@chakra-ui/react';
+import type { FunctionComponent, ReactNode } from 'react';
+
+export type CardProps = {
+  children?: ReactNode;
+};
+
+export const Card: FunctionComponent<CardProps> = ({ children }) => (
+  <Flex
+    flexDirection="column"
+    px="4"
+    py="4"
+    rounded="3xl"
+    boxShadow="lg"
+    backgroundColor="white"
+    height="167px"
+    _hover={{ backgroundColor: '#F8F8F8' }}
+  >
+    {children}
+  </Flex>
+);

--- a/src/components/LoadingCard.tsx
+++ b/src/components/LoadingCard.tsx
@@ -1,0 +1,11 @@
+import { SkeletonCircle, SkeletonText } from '@chakra-ui/react';
+import type { FunctionComponent } from 'react';
+
+import { Card } from './Card';
+
+export const LoadingCard: FunctionComponent = () => (
+  <Card>
+    <SkeletonCircle size="10" />
+    <SkeletonText mt="4" noOfLines={4} spacing="4" skeletonHeight="2" />
+  </Card>
+);

--- a/src/components/LoadingGrid.tsx
+++ b/src/components/LoadingGrid.tsx
@@ -1,0 +1,12 @@
+import { SimpleGrid } from '@chakra-ui/react';
+import type { FunctionComponent } from 'react';
+
+import { LoadingCard } from './LoadingCard';
+
+export const LoadingGrid: FunctionComponent = () => (
+  <SimpleGrid columns={[1, null, 2, 3]} spacing={4}>
+    {[...Array(6)].map((_, index) => (
+      <LoadingCard key={index} />
+    ))}
+  </SimpleGrid>
+);

--- a/src/components/SnapCard.tsx
+++ b/src/components/SnapCard.tsx
@@ -2,6 +2,7 @@ import { Flex, Text, Box } from '@chakra-ui/react';
 import { Link } from 'gatsby';
 import type { FunctionComponent } from 'react';
 
+import { Card } from './Card';
 import { SnapAuthorship } from './SnapAuthorship';
 import type { Fields } from '../utils';
 
@@ -10,16 +11,7 @@ export const SnapCard: FunctionComponent<
 > = ({ name, summary, snapId, icon, gatsbyPath }) => {
   return (
     <Link to={gatsbyPath}>
-      <Flex
-        flexDirection="column"
-        px="4"
-        py="4"
-        rounded="3xl"
-        boxShadow="lg"
-        backgroundColor="white"
-        height="167px"
-        _hover={{ backgroundColor: '#F8F8F8' }}
-      >
+      <Card>
         <Flex flexDirection="column">
           <Box marginBottom="4">
             <SnapAuthorship name={name} icon={icon} snapId={snapId} />
@@ -36,7 +28,7 @@ export const SnapCard: FunctionComponent<
             {summary}
           </Text>
         </Flex>
-      </Flex>
+      </Card>
     </Link>
   );
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './providers';
 export * from './BackButton';
+export * from './Card';
 export * from './Container';
 export * from './FilterButton';
 export * from './FilterCategory';
@@ -10,6 +11,8 @@ export * from './Icon';
 export * from './InstallSnapButton';
 export * from './InstallUnsupportedMobile';
 export * from './Layout';
+export * from './LoadingCard';
+export * from './LoadingGrid';
 export * from './Logo';
 export * from './PostInstallModal';
 export * from './SnapAudits';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,11 +24,14 @@ import {
   FilterMenu,
   RegistrySnapCategory,
   SNAP_CATEGORY_LABELS,
+  LoadingGrid,
 } from '../components';
 import { useEthereumProvider, useShuffledSnaps } from '../hooks';
 import type { Fields } from '../utils';
 
-const SnapsGrid = loadable(async () => import('../components/SnapsGrid'));
+const SnapsGrid = loadable(async () => import('../components/SnapsGrid'), {
+  fallback: <LoadingGrid />,
+});
 
 type IndexSnap = Fields<
   Queries.Snap,


### PR DESCRIPTION
This adds a grid with six skeleton cards as fallback, before the snap cards are loaded.