### PR TITLE
Keep newlines in snap descriptions

### DIFF
--- a/src/components/SnapDescription.tsx
+++ b/src/components/SnapDescription.tsx
@@ -33,27 +33,11 @@ export const SnapDescription: FunctionComponent<SnapDescriptionProps> = ({
 }) => {
   if (allowLinks) {
     return (
-      <Linkify
-        as={Text}
-        options={{ render }}
-        sx={{
-          whiteSpace: 'pre-wrap',
-        }}
-        {...props}
-      >
+      <Linkify as={Text} options={{ render }} {...props}>
         {description.description}
       </Linkify>
     );
   }
 
-  return (
-    <Text
-      sx={{
-        whiteSpace: 'pre-wrap',
-      }}
-      {...props}
-    >
-      {description.description}
-    </Text>
-  );
+  return <Text {...props}>{description.description}</Text>;
 };

--- a/src/components/SnapDescription.tsx
+++ b/src/components/SnapDescription.tsx
@@ -33,11 +33,27 @@ export const SnapDescription: FunctionComponent<SnapDescriptionProps> = ({
 }) => {
   if (allowLinks) {
     return (
-      <Linkify as={Text} options={{ render }} {...props}>
+      <Linkify
+        as={Text}
+        options={{ render }}
+        sx={{
+          whiteSpace: 'pre-wrap',
+        }}
+        {...props}
+      >
         {description.description}
       </Linkify>
     );
   }
 
-  return <Text {...props}>{description.description}</Text>;
+  return (
+    <Text
+      sx={{
+        whiteSpace: 'pre-wrap',
+      }}
+      {...props}
+    >
+      {description.description}
+    </Text>
+  );
 };

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -204,7 +204,11 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
             </Text>
           </Trans>
         </Text>
-        <SnapDescription description={description} mt="1" />
+        <SnapDescription
+          description={description}
+          mt="1"
+          whiteSpace="pre-wrap"
+        />
       </Box>
     </Container>
   );


### PR DESCRIPTION
Previously, newlines (`\n`) were ignored.