### PR TITLE
Deploy to GitHub Pages using personal token

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
         uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          personal_token: ${{ secrets.PUBLISH_PAGES_TOKEN }}
           publish_dir: ./public
           destination_dir: ${{ inputs.destination_dir }}


### PR DESCRIPTION
Instead of using the standard GitHub token, we want to use a personal access token, so we can properly protect the `gh-pages` branch.

Fixes #73 