### PR TITLE
Update cache path

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            .cache/npm
+            node_modules/.cache/npm
           key: npm-tarballs-${{ github.run_id }}
           restore-keys: |
             npm-tarballs

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -91,10 +91,10 @@ async function getRegistry() {
   };
 
   const cachedTarballFetch = fetchBuilder.withCache(
-    new FileSystemCache({ cacheDirectory: '.cache/npm/tarballs' }),
+    new FileSystemCache({ cacheDirectory: 'node_modules/.cache/npm/tarballs' }),
   );
 
-  const fetchCachePath = '.cache/npm/fetch';
+  const fetchCachePath = 'node_modules/.cache/npm/fetch';
   const cachedFetch = fetchBuilder.withCache(
     new FileSystemCache({ cacheDirectory: fetchCachePath }),
   );


### PR DESCRIPTION
Update cache path to use `node_modules/.cache` instead of `.cache` since the latter is often cleaned by Gatsby.