### PR TITLE
Check if `localStorage` exists before reading and writing

### DIFF
--- a/src/components/providers/EthereumProvider.tsx
+++ b/src/components/providers/EthereumProvider.tsx
@@ -58,6 +58,10 @@ async function getSnaps(
  * @returns The cached snaps.
  */
 function getCachedSnaps(): InstalledSnaps {
+  if (typeof localStorage === 'undefined') {
+    return {};
+  }
+
   try {
     const cachedSnaps = localStorage.getItem(LOCALSTORAGE_KEY);
     if (cachedSnaps) {
@@ -95,7 +99,7 @@ export const EthereumProvider: FunctionComponent<EthereumProviderProps> = ({
   }, [provider, updateSnaps]);
 
   useEffect(() => {
-    if (!snaps) {
+    if (!snaps || typeof localStorage === 'undefined') {
       return;
     }
 


### PR DESCRIPTION
Before this change, the following error would occur in the build process:

```
error ReferenceError: localStorage is not defined
    at getCachedSnaps (/home/runner/work/snaps-directory/snaps-directory/.cache/page-ssr/routes/webpack:/@metamask/snaps-directory/src/components/providers/EthereumProvider.tsx:62:25)
```