### PR TITLE
Forward token to workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,3 +75,4 @@ jobs:
       slack-subteam: S042S7RE4AE # @metamask-npm-publishers
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,6 +21,8 @@ on:
     secrets:
       SLACK_WEBHOOK_URL:
         required: false
+      PUBLISH_PAGES_TOKEN:
+        required: true
 
 jobs:
   announce-release:
@@ -92,3 +94,5 @@ jobs:
     uses: ./.github/workflows/publish-site.yml
     with:
       destination_dir: .
+    secrets:
+      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -9,6 +9,9 @@ on:
       ref:
         required: false
         type: string
+    secrets:
+      PUBLISH_PAGES_TOKEN:
+        required: true
 
 jobs:
   publish-site-to-gh-pages:


### PR DESCRIPTION
A secret token must be set in all workflows to be accessible.