### PR TITLE
Always show scrollbar

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -16,7 +16,7 @@ type LayoutProps = {
  * @returns A React component.
  */
 export const Layout: FunctionComponent<LayoutProps> = ({ children }) => (
-  <Flex direction="column" height="100vh">
+  <Flex direction="column" height="100vh" overflowY="scroll">
     <Header flexShrink="0" />
     <Flex as="main" direction="column" flexGrow="1">
       {children}


### PR DESCRIPTION
To avoid the website from jumping around too much, we want to always show a scrollbar.