### PR TITLE
Update Slack subteam and channel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       contents: write
     uses: ./.github/workflows/publish-release.yml
     with:
-      slack-subteam: S042S7RE4AE # @metamask-npm-publishers
+      slack-subteam: S05RL9W7H54 # @metamask-snaps-publishers
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ on:
       slack-channel:
         required: false
         type: string
-        default: 'metamask-dev'
+        default: 'metamask-snaps'
       slack-icon-url:
         required: false
         type: string

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -7,7 +7,7 @@ on:
         required: false
         type: string
         description: 'The Slack channel to post to.'
-        default: 'metamask-dev'
+        default: 'metamask-snaps'
       slack-icon-url:
         required: false
         type: string
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
         description: 'The Slack subteam to mention.'
-        default: 'S042S7RE4AE' # @metamask-npm-publishers
+        default: 'S05RL9W7H54' # @metamask-npm-publishers
       slack-username:
         required: false
         type: string


### PR DESCRIPTION
The message will now tag the Snaps publishers, and send a message in `metamask-snaps`.