### PR TITLE
Set overflow-y property on body

### DIFF
--- a/src/@chakra-ui/gatsby-plugin/theme.js
+++ b/src/@chakra-ui/gatsby-plugin/theme.js
@@ -58,6 +58,14 @@ const config = {
 const theme = extendTheme({
   config,
 
+  styles: {
+    global: {
+      body: {
+        overflowY: 'scroll',
+      },
+    },
+  },
+
   semanticTokens: {
     colors: {
       'chakra-body-bg': { _light: '#F8FAFC', _dark: '#24272A' },

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -16,7 +16,7 @@ type LayoutProps = {
  * @returns A React component.
  */
 export const Layout: FunctionComponent<LayoutProps> = ({ children }) => (
-  <Flex direction="column" height="100vh" overflowY="scroll">
+  <Flex direction="column" height="100vh">
     <Header flexShrink="0" />
     <Flex as="main" direction="column" flexGrow="1">
       {children}


### PR DESCRIPTION
Instead of adding `overflow-y` to the component inside the layout, we now add it to the body directly. This ensures that the page scrolls to the top when you navigate to a different page.