### PR TITLE
Persist search query and selected categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-use-fusejs": "^2.0.2",
+    "recoil": "^0.7.7",
     "semver": "^7.5.4"
   },
   "devDependencies": {

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,6 +1,7 @@
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import type { GatsbyBrowser } from 'gatsby';
+import { RecoilRoot } from 'recoil';
 
 import { EthereumProvider, Layout, SnapsProvider } from './components';
 import { messages } from './locales/en/messages';
@@ -45,10 +46,12 @@ export const wrapRootElement: GatsbyBrowser['wrapRootElement'] = ({
   element,
 }) => {
   return (
-    <I18nProvider i18n={i18n}>
-      <SnapsProvider>
-        <EthereumProvider>{element}</EthereumProvider>
-      </SnapsProvider>
-    </I18nProvider>
+    <RecoilRoot>
+      <I18nProvider i18n={i18n}>
+        <SnapsProvider>
+          <EthereumProvider>{element}</EthereumProvider>
+        </SnapsProvider>
+      </I18nProvider>
+    </RecoilRoot>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,8 +14,9 @@ import { t, Trans } from '@lingui/macro';
 import loadable from '@loadable/component';
 import { graphql } from 'gatsby';
 import type { ChangeEvent, FunctionComponent } from 'react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useGatsbyPluginFusejs } from 'react-use-fusejs';
+import { useRecoilState } from 'recoil';
 
 import banner from '../assets/images/seo/home.png';
 import type { InstalledSnaps } from '../components';
@@ -23,10 +24,10 @@ import {
   Icon,
   FilterMenu,
   RegistrySnapCategory,
-  SNAP_CATEGORY_LABELS,
   LoadingGrid,
 } from '../components';
 import { useEthereumProvider, useShuffledSnaps } from '../hooks';
+import { categoriesState, queryState } from '../state';
 import type { Fields } from '../utils';
 
 const SnapsGrid = loadable(async () => import('../components/SnapsGrid'), {
@@ -103,14 +104,13 @@ function getSnaps({
 }
 
 const IndexPage: FunctionComponent<IndexPageProps> = ({ data }) => {
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useRecoilState(queryState);
   const result = useGatsbyPluginFusejs<Queries.Snap>(query, data.fusejs, {
     threshold: 0.3,
   });
   const { snaps: installedSnaps } = useEthereumProvider();
-  const [selectedCategories, setSelectedCategories] = useState<
-    RegistrySnapCategory[]
-  >(Object.keys(SNAP_CATEGORY_LABELS) as RegistrySnapCategory[]);
+  const [selectedCategories, setSelectedCategories] =
+    useRecoilState(categoriesState);
   const shuffledSnaps = useShuffledSnaps();
 
   const snaps = useMemo(

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,20 @@
+import { atom } from 'recoil';
+
+import type { RegistrySnapCategory } from './components';
+import { SNAP_CATEGORY_LABELS } from './components';
+
+/**
+ * The search query.
+ */
+export const queryState = atom({
+  key: 'query',
+  default: '',
+});
+
+/**
+ * The selected categories in the filter.
+ */
+export const categoriesState = atom({
+  key: 'categories',
+  default: Object.keys(SNAP_CATEGORY_LABELS) as RegistrySnapCategory[],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5064,6 +5064,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-use-fusejs: ^2.0.2
+    recoil: ^0.7.7
     semver: ^7.5.4
     sharp: ^0.32.5
     simple-git-hooks: ^2.9.0
@@ -13039,6 +13040,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hamt_plus@npm:1.0.2":
+  version: 1.0.2
+  resolution: "hamt_plus@npm:1.0.2"
+  checksum: af26ea32db03009019cc83dfa9411521a2fa16079443de1a502c9be46d8b3c975acda8ed93fc5750ef08d3186d35901e2d8cfe717dd54bea67b358601fa74e4c
+  languageName: node
+  linkType: hard
+
 "hard-rejection@npm:^2.1.0":
   version: 2.1.0
   resolution: "hard-rejection@npm:2.1.0"
@@ -18356,6 +18364,22 @@ __metadata:
   dependencies:
     picomatch: ^2.2.1
   checksum: 6b1a9341e295e15d4fb40c010216cbcb6266587cd0b3ce7defabd66fa1b4e35f9fba3d64c2187fd38fadd01ccbfc5f1b33fdfb1da63b3cbf66224b7c6d75ce5a
+  languageName: node
+  linkType: hard
+
+"recoil@npm:^0.7.7":
+  version: 0.7.7
+  resolution: "recoil@npm:0.7.7"
+  dependencies:
+    hamt_plus: 1.0.2
+  peerDependencies:
+    react: ">=16.13.1"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 65edecbcb8d2cde89bfd61ec679c200483472a6cd343c33e4e9142b6ce524fb17d1fecc2bfd8c392926aaa8178c81457f165b32abce2a9662f51f98822c0a9cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #95.

This fixes an issue where if you search (or select a category), navigate, and go back, the search query is lost. I've fixed this by storing the search query and selected categories in a Recoil state.