### PR TITLE
Add more filtering options

### DIFF
--- a/src/components/FilterCategory.tsx
+++ b/src/components/FilterCategory.tsx
@@ -1,23 +1,24 @@
-import { MenuItem, Stack, Text } from '@chakra-ui/react';
+import { Box, Text } from '@chakra-ui/react';
 import { Trans } from '@lingui/react';
 import type { FunctionComponent } from 'react';
 
+import { FilterItem } from './FilterItem';
 import type { IconName } from './Icon';
 import { Icon } from './Icon';
-import type { RegistrySnapCategory } from './SnapCategory';
-import { SNAP_CATEGORY_LABELS } from './SnapCategory';
+import type { RegistrySnapCategory } from '../state';
+import { SNAP_CATEGORY_LABELS } from '../state';
 
 export type FilterCategoryProps = {
   category: RegistrySnapCategory;
   icon: IconName;
-  enabled: boolean;
+  checked: boolean;
   onToggle: (category: RegistrySnapCategory) => void;
 };
 
 export const FilterCategory: FunctionComponent<FilterCategoryProps> = ({
   category,
   icon,
-  enabled,
+  checked,
   onToggle,
 }) => {
   const handleClick = () => {
@@ -25,18 +26,12 @@ export const FilterCategory: FunctionComponent<FilterCategoryProps> = ({
   };
 
   return (
-    <MenuItem onClick={handleClick}>
-      <Stack direction="row" alignItems="center" gap="2">
-        <Icon
-          icon="checkBlue"
-          width="20px"
-          visibility={enabled ? 'initial' : 'hidden'}
-        />
-        <Icon icon={icon} width="32px" />
-        <Text>
-          <Trans id={SNAP_CATEGORY_LABELS[category].name.id} />
-        </Text>
-      </Stack>
-    </MenuItem>
+    <FilterItem checked={checked} onClick={handleClick}>
+      <Text>
+        <Trans id={SNAP_CATEGORY_LABELS[category].name.id} />
+      </Text>
+      <Box flexGrow={1} />
+      <Icon icon={icon} width="32px" />
+    </FilterItem>
   );
 };

--- a/src/components/FilterItem.tsx
+++ b/src/components/FilterItem.tsx
@@ -14,7 +14,7 @@ export const FilterItem: FunctionComponent<FilterItemProps> = ({
   children,
   ...props
 }) => (
-  <MenuItem height="48px" {...props}>
+  <MenuItem height="48px" borderRadius="sm" {...props}>
     <Stack direction="row" alignItems="center" gap="2" width="100%">
       <Icon
         icon="checkBlue"

--- a/src/components/FilterItem.tsx
+++ b/src/components/FilterItem.tsx
@@ -14,7 +14,7 @@ export const FilterItem: FunctionComponent<FilterItemProps> = ({
   children,
   ...props
 }) => (
-  <MenuItem height="48px" borderRadius="sm" {...props}>
+  <MenuItem height="48px" borderRadius="md" {...props}>
     <Stack direction="row" alignItems="center" gap="2" width="100%">
       <Icon
         icon="checkBlue"

--- a/src/components/FilterItem.tsx
+++ b/src/components/FilterItem.tsx
@@ -1,0 +1,27 @@
+import type { MenuItemProps } from '@chakra-ui/react';
+import { MenuItem, Stack } from '@chakra-ui/react';
+import type { FunctionComponent, ReactNode } from 'react';
+
+import { Icon } from './Icon';
+
+export type FilterItemProps = MenuItemProps & {
+  checked: boolean;
+  children: ReactNode;
+};
+
+export const FilterItem: FunctionComponent<FilterItemProps> = ({
+  checked,
+  children,
+  ...props
+}) => (
+  <MenuItem height="48px" {...props}>
+    <Stack direction="row" alignItems="center" gap="2" width="100%">
+      <Icon
+        icon="checkBlue"
+        width="20px"
+        visibility={checked ? 'initial' : 'hidden'}
+      />
+      {children}
+    </Stack>
+  </MenuItem>
+);

--- a/src/components/FilterMenu.tsx
+++ b/src/components/FilterMenu.tsx
@@ -1,25 +1,57 @@
-import { Menu, MenuButton, MenuGroup, MenuList } from '@chakra-ui/react';
-import { t } from '@lingui/macro';
+import { Menu, MenuButton, MenuGroup, MenuList, Text } from '@chakra-ui/react';
+import { t, Trans } from '@lingui/macro';
 import type { FunctionComponent } from 'react';
 
 import { FilterButton } from './FilterButton';
 import { FilterCategory } from './FilterCategory';
-import type { RegistrySnapCategory } from './SnapCategory';
-import { SNAP_CATEGORY_LABELS } from './SnapCategory';
+import { FilterItem } from './FilterItem';
+import {
+  SELECT_ALL,
+  SELECT_CATEGORY,
+  SELECT_INSTALLED,
+  useFilter,
+} from '../hooks';
+import type { RegistrySnapCategory } from '../state';
+import { SNAP_CATEGORY_LABELS } from '../state';
 
-export type FilterMenuProps = {
-  selectedCategories: RegistrySnapCategory[];
-  onToggle: (category: RegistrySnapCategory) => void;
-};
+export const FilterMenu: FunctionComponent = () => {
+  const [state, dispatch] = useFilter();
 
-export const FilterMenu: FunctionComponent<FilterMenuProps> = ({
-  selectedCategories,
-  onToggle,
-}) => {
+  const handleClickAll = () => {
+    dispatch({
+      type: SELECT_ALL,
+    });
+  };
+
+  const handleClickInstalled = () => {
+    dispatch({
+      type: SELECT_INSTALLED,
+    });
+  };
+
+  const handleToggle = (category: RegistrySnapCategory) => {
+    dispatch({
+      type: SELECT_CATEGORY,
+      payload: category,
+    });
+  };
+
   return (
     <Menu closeOnSelect={false}>
       <MenuButton as={FilterButton} />
       <MenuList>
+        <MenuGroup marginLeft="2" title={t`Filter`}>
+          <FilterItem checked={state.all} onClick={handleClickAll}>
+            <Text>
+              <Trans>All</Trans>
+            </Text>
+          </FilterItem>
+          <FilterItem checked={state.installed} onClick={handleClickInstalled}>
+            <Text>
+              <Trans>Installed</Trans>
+            </Text>
+          </FilterItem>
+        </MenuGroup>
         <MenuGroup marginLeft="2" title={t`Categories`}>
           {Object.entries(SNAP_CATEGORY_LABELS).map(
             ([category, { name, icon }]) => (
@@ -27,10 +59,10 @@ export const FilterMenu: FunctionComponent<FilterMenuProps> = ({
                 key={name.id}
                 category={category as RegistrySnapCategory}
                 icon={icon}
-                enabled={selectedCategories.includes(
+                checked={state.categories.includes(
                   category as RegistrySnapCategory,
                 )}
-                onToggle={onToggle}
+                onToggle={handleToggle}
               />
             ),
           )}

--- a/src/components/SnapCategory.tsx
+++ b/src/components/SnapCategory.tsx
@@ -1,34 +1,9 @@
 import { Text } from '@chakra-ui/react';
-import type { MessageDescriptor } from '@lingui/core';
-import { defineMessage } from '@lingui/macro';
 import { Trans } from '@lingui/react';
 import type { FunctionComponent } from 'react';
 
-import type { IconName } from './Icon';
-
-export enum RegistrySnapCategory {
-  Interoperability = 'interoperability',
-  Notifications = 'notifications',
-  TransactionInsights = 'transaction insights',
-}
-
-export const SNAP_CATEGORY_LABELS: Record<
-  RegistrySnapCategory,
-  { name: MessageDescriptor; icon: IconName }
-> = {
-  [RegistrySnapCategory.Interoperability]: {
-    name: defineMessage`Interoperability`,
-    icon: 'interoperability',
-  },
-  [RegistrySnapCategory.Notifications]: {
-    name: defineMessage`Notifications`,
-    icon: 'notifications',
-  },
-  [RegistrySnapCategory.TransactionInsights]: {
-    name: defineMessage`Transaction Insights`,
-    icon: 'transactionInsights',
-  },
-};
+import type { RegistrySnapCategory } from '../state';
+import { SNAP_CATEGORY_LABELS } from '../state';
 
 export type SnapCategoryProps = {
   category: RegistrySnapCategory;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useEthereumProvider';
+export * from './useFilter';
 export * from './useShuffledSnaps';
 export * from './useSupportedVersion';

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -1,0 +1,106 @@
+import { useEffect, useReducer } from 'react';
+import { useRecoilState } from 'recoil';
+
+import type { FilterState, RegistrySnapCategory } from '../state';
+import {
+  filterState,
+  INITIAL_CATEGORIES,
+  INITIAL_FILTER_STATE,
+} from '../state';
+
+export const SELECT_ALL = 'SELECT_ALL';
+export type SelectAllAction = {
+  type: typeof SELECT_ALL;
+};
+
+export const SELECT_INSTALLED = 'SELECT_INSTALLED';
+export type SelectInstalledAction = {
+  type: typeof SELECT_INSTALLED;
+};
+
+export const SELECT_CATEGORY = 'SELECT_CATEGORY';
+export type SelectCategoryAction = {
+  type: typeof SELECT_CATEGORY;
+  payload: RegistrySnapCategory;
+};
+
+export type FilterAction =
+  | SelectAllAction
+  | SelectInstalledAction
+  | SelectCategoryAction;
+
+/**
+ * A reducer to manage the filter state.
+ *
+ * The filter state is composed of three parts:
+ *
+ * - `all`: A boolean indicating whether all snaps should be shown.
+ * - `installed`: A boolean indicating whether only installed snaps should be
+ * shown.
+ * - `categories`: An array of categories to filter by.
+ *
+ * The `all` and `installed` properties are mutually exclusive. If `all` is
+ * `true`, then `installed` must be `false`, and vice versa.
+ *
+ * @param state - The current filter state.
+ * @param action - The action to perform on the filter state.
+ * @returns The new filter state.
+ */
+function reducer(state: FilterState, action: FilterAction) {
+  switch (action.type) {
+    case SELECT_ALL:
+      return INITIAL_FILTER_STATE;
+
+    case SELECT_INSTALLED:
+      return {
+        ...state,
+        all: false,
+        installed: true,
+        categories: INITIAL_CATEGORIES,
+      };
+
+    case SELECT_CATEGORY: {
+      const { payload } = action;
+      return {
+        ...state,
+        all: false,
+        categories: [payload],
+      };
+    }
+
+    default:
+      return state;
+  }
+}
+
+export type FilterDispatch = (action: FilterAction) => void;
+
+/**
+ * A hook to manage the filter state.
+ *
+ * The filter state is composed of three parts:
+ *
+ * - `all`: A boolean indicating whether all snaps should be shown.
+ * - `installed`: A boolean indicating whether only installed snaps should be
+ * shown.
+ * - `categories`: An array of categories to filter by.
+ *
+ * The `all` and `installed` properties are mutually exclusive. If `all` is
+ * `true`, then `installed` must be `false`, and vice versa.
+ *
+ * @returns The state and dispatch functions for the filter state.
+ */
+export function useFilter() {
+  const [state, setState] = useRecoilState(filterState);
+  const [reducerState, dispatch] = useReducer(reducer, state);
+
+  useEffect(() => {
+    // To persist the filter state, we need to update the Recoil state whenever
+    // the reducer state changes.
+    setState(reducerState);
+  }, [reducerState, setState]);
+
+  // Note: We return the Recoil state instead of the reducer state so that it's
+  // synchronized with any components that use the hook.
+  return [state, dispatch] as const;
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -30,6 +30,10 @@ msgstr ""
 msgid "Add to MetaMask"
 msgstr ""
 
+#: src/components/FilterMenu.tsx
+msgid "All"
+msgstr ""
+
 #: src/pages/snap/{Snap.location}/{Snap.slug}.tsx
 msgid "Audit"
 msgstr ""
@@ -112,6 +116,7 @@ msgid "Feedback"
 msgstr ""
 
 #: src/components/FilterButton.tsx
+#: src/components/FilterMenu.tsx
 #: src/components/Icon.tsx
 msgid "Filter"
 msgstr ""
@@ -137,6 +142,7 @@ msgstr ""
 msgid "Installation complete"
 msgstr ""
 
+#: src/components/FilterMenu.tsx
 #: src/components/InstallSnapButton.tsx
 msgid "Installed"
 msgstr ""
@@ -147,7 +153,7 @@ msgstr ""
 
 #: src/components/Icon.tsx
 #: src/components/Icon.tsx
-#: src/components/SnapCategory.tsx
+#: src/state.ts
 msgid "Interoperability"
 msgstr ""
 
@@ -165,7 +171,7 @@ msgstr ""
 
 #: src/components/Icon.tsx
 #: src/components/Icon.tsx
-#: src/components/SnapCategory.tsx
+#: src/state.ts
 msgid "Notifications"
 msgstr ""
 
@@ -217,7 +223,7 @@ msgstr ""
 
 #: src/components/Icon.tsx
 #: src/components/Icon.tsx
-#: src/components/SnapCategory.tsx
+#: src/state.ts
 msgid "Transaction Insights"
 msgstr ""
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,7 +1,53 @@
+import type { MessageDescriptor } from '@lingui/core';
+import { defineMessage } from '@lingui/macro';
 import { atom } from 'recoil';
 
-import type { RegistrySnapCategory } from './components';
-import { SNAP_CATEGORY_LABELS } from './components';
+import type { IconName } from './components';
+
+export enum RegistrySnapCategory {
+  Interoperability = 'interoperability',
+  Notifications = 'notifications',
+  TransactionInsights = 'transaction insights',
+}
+
+export const SNAP_CATEGORY_LABELS: Record<
+  RegistrySnapCategory,
+  { name: MessageDescriptor; icon: IconName }
+> = {
+  [RegistrySnapCategory.Interoperability]: {
+    name: defineMessage`Interoperability`,
+    icon: 'interoperability',
+  },
+  [RegistrySnapCategory.Notifications]: {
+    name: defineMessage`Notifications`,
+    icon: 'notifications',
+  },
+  [RegistrySnapCategory.TransactionInsights]: {
+    name: defineMessage`Transaction Insights`,
+    icon: 'transactionInsights',
+  },
+};
+
+export type FilterState = {
+  all: boolean;
+  installed: boolean;
+  categories: RegistrySnapCategory[];
+};
+
+export const INITIAL_CATEGORIES = Object.keys(
+  SNAP_CATEGORY_LABELS,
+) as RegistrySnapCategory[];
+
+export const INITIAL_FILTER_STATE: FilterState = {
+  all: true,
+  installed: false,
+  categories: INITIAL_CATEGORIES,
+};
+
+export const filterState = atom({
+  key: 'filter',
+  default: INITIAL_FILTER_STATE,
+});
 
 /**
  * The search query.


### PR DESCRIPTION
This pull request changes the filtering behaviour, and adds more filtering options:

- Installed snaps are no longer sorted separately from the other snaps.
- The filter menu now has an option to show only installed snaps.
- Clicking on a category will select only that category.

Closes MetaMask/metamask-planning#1340.