### PR TITLE
Add category tags and update filter behaviour

### DIFF
--- a/src/@chakra-ui/gatsby-plugin/theme.js
+++ b/src/@chakra-ui/gatsby-plugin/theme.js
@@ -141,6 +141,7 @@ const theme = extendTheme({
     },
     success: {
       default: '#579F6E',
+      muted: 'rgba(40, 167, 69, 0.1)',
     },
     gray: {
       40: '#F2F4F6',

--- a/src/@chakra-ui/gatsby-plugin/theme.js
+++ b/src/@chakra-ui/gatsby-plugin/theme.js
@@ -322,6 +322,15 @@ const theme = extendTheme({
             fontFamily: 'code',
           },
         }),
+
+        category: {
+          container: {
+            lineHeight: '1.5',
+            textTransform: 'none',
+            paddingX: '3',
+            paddingY: '2',
+          },
+        },
       },
     }),
 

--- a/src/components/CloseIcon.tsx
+++ b/src/components/CloseIcon.tsx
@@ -1,0 +1,31 @@
+import type { BoxProps } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
+import type { FunctionComponent } from 'react';
+
+export type CloseIconProps = BoxProps;
+
+export const CloseIcon: FunctionComponent<CloseIconProps> = (props) => (
+  <Flex
+    display="inline-flex"
+    justifyContent="center"
+    width="16px"
+    marginLeft="1"
+    transition="all 0.2s"
+    _hover={{
+      cursor: 'pointer',
+      opacity: '0.8',
+    }}
+    {...props}
+  >
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M1.25922 11.3334C1.08144 11.3334 0.962922 11.2741 0.844404 11.1556C0.607367 10.9185 0.607367 10.563 0.844404 10.3259L10.3259 0.844465C10.5629 0.607428 10.9185 0.607428 11.1555 0.844465C11.3926 1.0815 11.3926 1.43706 11.1555 1.67409L1.67403 11.1556C1.55551 11.2741 1.437 11.3334 1.25922 11.3334Z" />
+      <path d="M10.7407 11.3334C10.5629 11.3334 10.4444 11.2741 10.3259 11.1556L0.844404 1.67409C0.607367 1.43706 0.607367 1.0815 0.844404 0.844465C1.08144 0.607428 1.437 0.607428 1.67403 0.844465L11.1555 10.3259C11.3926 10.563 11.3926 10.9185 11.1555 11.1556C11.037 11.2741 10.9185 11.3334 10.7407 11.3334Z" />
+    </svg>
+  </Flex>
+);

--- a/src/components/FilterCategory.tsx
+++ b/src/components/FilterCategory.tsx
@@ -5,28 +5,38 @@ import type { FunctionComponent } from 'react';
 import { FilterItem } from './FilterItem';
 import type { IconName } from './Icon';
 import { Icon } from './Icon';
+import { SELECT_CATEGORY, UNSELECT_CATEGORY, useFilter } from '../hooks';
 import type { RegistrySnapCategory } from '../state';
 import { SNAP_CATEGORY_LABELS } from '../state';
 
 export type FilterCategoryProps = {
   category: RegistrySnapCategory;
   icon: IconName;
-  checked: boolean;
-  onToggle: (category: RegistrySnapCategory) => void;
 };
 
 export const FilterCategory: FunctionComponent<FilterCategoryProps> = ({
   category,
   icon,
-  checked,
-  onToggle,
 }) => {
+  const [state, dispatch] = useFilter();
+  const isChecked = state.categories.includes(category);
+
   const handleClick = () => {
-    onToggle(category);
+    if (isChecked) {
+      return dispatch({
+        type: UNSELECT_CATEGORY,
+        payload: category,
+      });
+    }
+
+    return dispatch({
+      type: SELECT_CATEGORY,
+      payload: category,
+    });
   };
 
   return (
-    <FilterItem checked={checked} onClick={handleClick}>
+    <FilterItem checked={isChecked} onClick={handleClick}>
       <Text>
         <Trans id={SNAP_CATEGORY_LABELS[category].name.id} />
       </Text>

--- a/src/components/FilterMenu.tsx
+++ b/src/components/FilterMenu.tsx
@@ -5,6 +5,7 @@ import type { FunctionComponent } from 'react';
 import { FilterButton } from './FilterButton';
 import { FilterCategory } from './FilterCategory';
 import { FilterItem } from './FilterItem';
+import { FilterTags } from './FilterTags';
 import { SELECT_ALL, SELECT_INSTALLED, useFilter } from '../hooks';
 import { RegistrySnapCategory, SNAP_CATEGORY_LABELS } from '../state';
 
@@ -24,40 +25,46 @@ export const FilterMenu: FunctionComponent = () => {
   };
 
   return (
-    <Menu closeOnSelect={false}>
-      <MenuButton as={FilterButton} />
-      <MenuList>
-        <MenuGroup marginLeft="2" title={t`Filter`}>
-          <FilterItem
-            checked={
-              !state.installed &&
-              state.categories.length ===
-                Object.values(RegistrySnapCategory).length
-            }
-            onClick={handleClickAll}
-          >
-            <Text>
-              <Trans>All</Trans>
-            </Text>
-          </FilterItem>
-          <FilterItem checked={state.installed} onClick={handleClickInstalled}>
-            <Text>
-              <Trans>Installed</Trans>
-            </Text>
-          </FilterItem>
-        </MenuGroup>
-        <MenuGroup marginLeft="2" title={t`Categories`}>
-          {Object.entries(SNAP_CATEGORY_LABELS).map(
-            ([category, { name, icon }]) => (
-              <FilterCategory
-                key={name.id}
-                category={category as RegistrySnapCategory}
-                icon={icon}
-              />
-            ),
-          )}
-        </MenuGroup>
-      </MenuList>
-    </Menu>
+    <>
+      <Menu closeOnSelect={false}>
+        <MenuButton as={FilterButton} order={[3, null, 0]} />
+        <MenuList width="275px">
+          <MenuGroup marginLeft="2" title={t`Filter`}>
+            <FilterItem
+              checked={
+                !state.installed &&
+                state.categories.length ===
+                  Object.values(RegistrySnapCategory).length
+              }
+              onClick={handleClickAll}
+            >
+              <Text>
+                <Trans>All</Trans>
+              </Text>
+            </FilterItem>
+            <FilterItem
+              checked={state.installed}
+              onClick={handleClickInstalled}
+            >
+              <Text>
+                <Trans>Installed</Trans>
+              </Text>
+            </FilterItem>
+          </MenuGroup>
+          <MenuGroup marginLeft="2" title={t`Categories`}>
+            {Object.entries(SNAP_CATEGORY_LABELS).map(
+              ([category, { name, icon }]) => (
+                <FilterCategory
+                  key={name.id}
+                  category={category as RegistrySnapCategory}
+                  icon={icon}
+                />
+              ),
+            )}
+          </MenuGroup>
+        </MenuList>
+      </Menu>
+      <FilterTags display={['none', null, 'flex']} />
+    </>
   );
 };

--- a/src/components/FilterMenu.tsx
+++ b/src/components/FilterMenu.tsx
@@ -5,14 +5,8 @@ import type { FunctionComponent } from 'react';
 import { FilterButton } from './FilterButton';
 import { FilterCategory } from './FilterCategory';
 import { FilterItem } from './FilterItem';
-import {
-  SELECT_ALL,
-  SELECT_CATEGORY,
-  SELECT_INSTALLED,
-  useFilter,
-} from '../hooks';
-import type { RegistrySnapCategory } from '../state';
-import { SNAP_CATEGORY_LABELS } from '../state';
+import { SELECT_ALL, SELECT_INSTALLED, useFilter } from '../hooks';
+import { RegistrySnapCategory, SNAP_CATEGORY_LABELS } from '../state';
 
 export const FilterMenu: FunctionComponent = () => {
   const [state, dispatch] = useFilter();
@@ -29,19 +23,19 @@ export const FilterMenu: FunctionComponent = () => {
     });
   };
 
-  const handleToggle = (category: RegistrySnapCategory) => {
-    dispatch({
-      type: SELECT_CATEGORY,
-      payload: category,
-    });
-  };
-
   return (
     <Menu closeOnSelect={false}>
       <MenuButton as={FilterButton} />
       <MenuList>
         <MenuGroup marginLeft="2" title={t`Filter`}>
-          <FilterItem checked={state.all} onClick={handleClickAll}>
+          <FilterItem
+            checked={
+              !state.installed &&
+              state.categories.length ===
+                Object.values(RegistrySnapCategory).length
+            }
+            onClick={handleClickAll}
+          >
             <Text>
               <Trans>All</Trans>
             </Text>
@@ -59,10 +53,6 @@ export const FilterMenu: FunctionComponent = () => {
                 key={name.id}
                 category={category as RegistrySnapCategory}
                 icon={icon}
-                checked={state.categories.includes(
-                  category as RegistrySnapCategory,
-                )}
-                onToggle={handleToggle}
               />
             ),
           )}

--- a/src/components/FilterTag.tsx
+++ b/src/components/FilterTag.tsx
@@ -1,7 +1,8 @@
-import { Tag, TagCloseButton, TagLabel } from '@chakra-ui/react';
+import { Tag, TagLabel } from '@chakra-ui/react';
 import { Trans } from '@lingui/react';
 import type { FunctionComponent } from 'react';
 
+import { CloseIcon } from './CloseIcon';
 import { UNSELECT_CATEGORY, useFilter } from '../hooks';
 import type { RegistrySnapCategory } from '../state';
 import { SNAP_CATEGORY_LABELS } from '../state';
@@ -25,7 +26,7 @@ export const FilterTag: FunctionComponent<FilterTagProps> = ({ category }) => {
       <TagLabel>
         <Trans id={SNAP_CATEGORY_LABELS[category].name.id} />
       </TagLabel>
-      <TagCloseButton onClick={handleClick} />
+      <CloseIcon onClick={handleClick} />
     </Tag>
   );
 };

--- a/src/components/FilterTag.tsx
+++ b/src/components/FilterTag.tsx
@@ -1,0 +1,31 @@
+import { Tag, TagCloseButton, TagLabel } from '@chakra-ui/react';
+import { Trans } from '@lingui/react';
+import type { FunctionComponent } from 'react';
+
+import { UNSELECT_CATEGORY, useFilter } from '../hooks';
+import type { RegistrySnapCategory } from '../state';
+import { SNAP_CATEGORY_LABELS } from '../state';
+
+export type FilterTagProps = {
+  category: RegistrySnapCategory;
+};
+
+export const FilterTag: FunctionComponent<FilterTagProps> = ({ category }) => {
+  const [, dispatch] = useFilter();
+
+  const handleClick = () => {
+    dispatch({
+      type: UNSELECT_CATEGORY,
+      payload: category,
+    });
+  };
+
+  return (
+    <Tag variant="category">
+      <TagLabel>
+        <Trans id={SNAP_CATEGORY_LABELS[category].name.id} />
+      </TagLabel>
+      <TagCloseButton onClick={handleClick} />
+    </Tag>
+  );
+};

--- a/src/components/FilterTags.tsx
+++ b/src/components/FilterTags.tsx
@@ -1,7 +1,8 @@
-import { Stack, Tag, TagCloseButton, TagLabel } from '@chakra-ui/react';
+import { Stack, Tag, TagLabel } from '@chakra-ui/react';
 import { Trans } from '@lingui/macro';
 import type { FunctionComponent } from 'react';
 
+import { CloseIcon } from './CloseIcon';
 import { FilterMenu } from './FilterMenu';
 import { FilterTag } from './FilterTag';
 import { UNSELECT_INSTALLED, useFilter } from '../hooks';
@@ -22,11 +23,15 @@ export const FilterTags: FunctionComponent = () => {
         <FilterTag key={category} category={category} />
       ))}
       {state.installed && (
-        <Tag variant="category">
+        <Tag
+          variant="category"
+          background="success.muted"
+          color="success.default"
+        >
           <TagLabel>
             <Trans>Installed</Trans>
           </TagLabel>
-          <TagCloseButton onClick={handleClickInstalled} />
+          <CloseIcon onClick={handleClickInstalled} />
         </Tag>
       )}
     </Stack>

--- a/src/components/FilterTags.tsx
+++ b/src/components/FilterTags.tsx
@@ -1,13 +1,15 @@
+import type { StackProps } from '@chakra-ui/react';
 import { Stack, Tag, TagLabel } from '@chakra-ui/react';
 import { Trans } from '@lingui/macro';
 import type { FunctionComponent } from 'react';
 
 import { CloseIcon } from './CloseIcon';
-import { FilterMenu } from './FilterMenu';
 import { FilterTag } from './FilterTag';
 import { UNSELECT_INSTALLED, useFilter } from '../hooks';
 
-export const FilterTags: FunctionComponent = () => {
+export type FilterTagsProps = StackProps;
+
+export const FilterTags: FunctionComponent<FilterTagsProps> = (props) => {
   const [state, dispatch] = useFilter();
 
   const handleClickInstalled = () => {
@@ -17,8 +19,7 @@ export const FilterTags: FunctionComponent = () => {
   };
 
   return (
-    <Stack direction="row" spacing={2}>
-      <FilterMenu />
+    <Stack direction="row" spacing={2} {...props}>
       {state.categories.map((category) => (
         <FilterTag key={category} category={category} />
       ))}

--- a/src/components/FilterTags.tsx
+++ b/src/components/FilterTags.tsx
@@ -1,0 +1,34 @@
+import { Stack, Tag, TagCloseButton, TagLabel } from '@chakra-ui/react';
+import { Trans } from '@lingui/macro';
+import type { FunctionComponent } from 'react';
+
+import { FilterMenu } from './FilterMenu';
+import { FilterTag } from './FilterTag';
+import { UNSELECT_INSTALLED, useFilter } from '../hooks';
+
+export const FilterTags: FunctionComponent = () => {
+  const [state, dispatch] = useFilter();
+
+  const handleClickInstalled = () => {
+    dispatch({
+      type: UNSELECT_INSTALLED,
+    });
+  };
+
+  return (
+    <Stack direction="row" spacing={2}>
+      <FilterMenu />
+      {state.categories.map((category) => (
+        <FilterTag key={category} category={category} />
+      ))}
+      {state.installed && (
+        <Tag variant="category">
+          <TagLabel>
+            <Trans>Installed</Trans>
+          </TagLabel>
+          <TagCloseButton onClick={handleClickInstalled} />
+        </Tag>
+      )}
+    </Stack>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,7 @@ export * from './Container';
 export * from './FilterButton';
 export * from './FilterCategory';
 export * from './FilterMenu';
+export * from './FilterTags';
 export * from './Fox';
 export * from './Header';
 export * from './Icon';

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -90,14 +90,6 @@ function reducer(state: FilterState, action: FilterAction) {
       );
 
       if (categories.length === 0) {
-        if (state.installed) {
-          return {
-            ...state,
-            installed: true,
-            categories: INITIAL_CATEGORIES,
-          };
-        }
-
         return {
           ...state,
           categories: INITIAL_CATEGORIES,

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -1,6 +1,4 @@
-import { useEffect, useReducer } from 'react';
-import { useRecoilState } from 'recoil';
-
+import { createReducer, useRecoilReducer } from './useRecoilReducer';
 import type { FilterState, RegistrySnapCategory } from '../state';
 import {
   filterState,
@@ -18,29 +16,38 @@ export type SelectInstalledAction = {
   type: typeof SELECT_INSTALLED;
 };
 
+export const UNSELECT_INSTALLED = 'UNSELECT_INSTALLED';
+export type UnselectInstalledAction = {
+  type: typeof UNSELECT_INSTALLED;
+};
+
 export const SELECT_CATEGORY = 'SELECT_CATEGORY';
 export type SelectCategoryAction = {
   type: typeof SELECT_CATEGORY;
   payload: RegistrySnapCategory;
 };
 
+export const UNSELECT_CATEGORY = 'UNSELECT_CATEGORY';
+export type UnselectCategoryAction = {
+  type: typeof UNSELECT_CATEGORY;
+  payload: RegistrySnapCategory;
+};
+
 export type FilterAction =
   | SelectAllAction
   | SelectInstalledAction
-  | SelectCategoryAction;
+  | UnselectInstalledAction
+  | SelectCategoryAction
+  | UnselectCategoryAction;
 
 /**
  * A reducer to manage the filter state.
  *
- * The filter state is composed of three parts:
+ * The filter state is composed of two parts:
  *
- * - `all`: A boolean indicating whether all snaps should be shown.
  * - `installed`: A boolean indicating whether only installed snaps should be
  * shown.
  * - `categories`: An array of categories to filter by.
- *
- * The `all` and `installed` properties are mutually exclusive. If `all` is
- * `true`, then `installed` must be `false`, and vice versa.
  *
  * @param state - The current filter state.
  * @param action - The action to perform on the filter state.
@@ -54,17 +61,52 @@ function reducer(state: FilterState, action: FilterAction) {
     case SELECT_INSTALLED:
       return {
         ...state,
-        all: false,
         installed: true,
         categories: INITIAL_CATEGORIES,
       };
 
-    case SELECT_CATEGORY: {
-      const { payload } = action;
+    case UNSELECT_INSTALLED:
       return {
         ...state,
-        all: false,
-        categories: [payload],
+        installed: false,
+      };
+
+    case SELECT_CATEGORY: {
+      const { payload } = action;
+      const categories = state.categories.filter(
+        (category) => category !== payload,
+      );
+
+      return {
+        ...state,
+        categories: [...categories, payload],
+      };
+    }
+
+    case UNSELECT_CATEGORY: {
+      const { payload } = action;
+      const categories = state.categories.filter(
+        (category) => category !== payload,
+      );
+
+      if (categories.length === 0) {
+        if (state.installed) {
+          return {
+            ...state,
+            installed: true,
+            categories: INITIAL_CATEGORIES,
+          };
+        }
+
+        return {
+          ...state,
+          categories: INITIAL_CATEGORIES,
+        };
+      }
+
+      return {
+        ...state,
+        categories,
       };
     }
 
@@ -73,34 +115,20 @@ function reducer(state: FilterState, action: FilterAction) {
   }
 }
 
-export type FilterDispatch = (action: FilterAction) => void;
+// The Recoil selector is created here to avoid creating it multiple times.
+const filterReducer = createReducer(filterState, reducer);
 
 /**
  * A hook to manage the filter state.
  *
- * The filter state is composed of three parts:
+ * The filter state is composed of two parts:
  *
- * - `all`: A boolean indicating whether all snaps should be shown.
  * - `installed`: A boolean indicating whether only installed snaps should be
  * shown.
  * - `categories`: An array of categories to filter by.
  *
- * The `all` and `installed` properties are mutually exclusive. If `all` is
- * `true`, then `installed` must be `false`, and vice versa.
- *
  * @returns The state and dispatch functions for the filter state.
  */
 export function useFilter() {
-  const [state, setState] = useRecoilState(filterState);
-  const [reducerState, dispatch] = useReducer(reducer, state);
-
-  useEffect(() => {
-    // To persist the filter state, we need to update the Recoil state whenever
-    // the reducer state changes.
-    setState(reducerState);
-  }, [reducerState, setState]);
-
-  // Note: We return the Recoil state instead of the reducer state so that it's
-  // synchronized with any components that use the hook.
-  return [state, dispatch] as const;
+  return useRecoilReducer(filterState, filterReducer);
 }

--- a/src/hooks/useRecoilReducer.ts
+++ b/src/hooks/useRecoilReducer.ts
@@ -1,0 +1,52 @@
+import type { Reducer } from 'react';
+import type { RecoilState } from 'recoil';
+import {
+  DefaultValue,
+  selector as select,
+  useRecoilValue,
+  useSetRecoilState,
+} from 'recoil';
+
+/**
+ * Creates a Recoil selector that wraps a reducer. The Recoil selector is
+ * write-only, and the reducer is used to update the state of the Recoil atom.
+ *
+ * @param atom - The Recoil atom to wrap.
+ * @param reducer - The reducer function.
+ * @returns A Recoil selector that wraps the reducer.
+ */
+export function createReducer<State, Action>(
+  atom: RecoilState<State>,
+  reducer: Reducer<State, Action>,
+) {
+  return select<Action>({
+    key: `${atom.key}-dispatch`,
+    get: () => {
+      throw new Error('The dispatch function is read-only.');
+    },
+    set: ({ get, set }, action) => {
+      if (action instanceof DefaultValue) {
+        return;
+      }
+
+      set(atom, reducer(get(atom), action));
+    },
+  });
+}
+
+/**
+ * A hook that wraps a Recoil atom with a reducer.
+ *
+ * @param atom - The Recoil atom to wrap.
+ * @param reducer - The reducer function.
+ * @returns A tuple containing the state and dispatch function.
+ */
+export function useRecoilReducer<State, Action>(
+  atom: RecoilState<State>,
+  reducer: RecoilState<Action>,
+) {
+  const state = useRecoilValue(atom);
+  const dispatch = useSetRecoilState(reducer);
+
+  return [state, dispatch] as const;
+}

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -143,6 +143,7 @@ msgid "Installation complete"
 msgstr ""
 
 #: src/components/FilterMenu.tsx
+#: src/components/FilterTags.tsx
 #: src/components/InstallSnapButton.tsx
 msgid "Installed"
 msgstr ""

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,7 +8,6 @@ import {
   Input,
   InputGroup,
   InputLeftElement,
-  Stack,
 } from '@chakra-ui/react';
 import { t, Trans } from '@lingui/macro';
 import loadable from '@loadable/component';
@@ -19,8 +18,8 @@ import { useGatsbyPluginFusejs } from 'react-use-fusejs';
 import { useRecoilState } from 'recoil';
 
 import banner from '../assets/images/seo/home.png';
-import type { InstalledSnaps } from '../components';
-import { Icon, FilterMenu, LoadingGrid } from '../components';
+import type { InstalledSnaps, Snap } from '../components';
+import { Icon, LoadingGrid, FilterTags } from '../components';
 import { useEthereumProvider, useShuffledSnaps, useFilter } from '../hooks';
 import type { FilterState, RegistrySnapCategory } from '../state';
 import { queryState } from '../state';
@@ -30,11 +29,6 @@ const SnapsGrid = loadable(async () => import('../components/SnapsGrid'), {
   fallback: <LoadingGrid />,
 });
 
-type IndexSnap = Fields<
-  Queries.Snap,
-  'id' | 'snapId' | 'name' | 'description' | 'icon' | 'category' | 'gatsbyPath'
->;
-
 type IndexPageProps = {
   data: {
     fusejs: Queries.fusejs;
@@ -42,7 +36,7 @@ type IndexPageProps = {
 };
 
 type GetSnapsArgs = {
-  snaps: IndexSnap[];
+  snaps: Snap[];
   installedSnaps: InstalledSnaps;
   filter: FilterState;
   searchQuery: string;
@@ -74,12 +68,8 @@ function getSnaps({
           .map((searchResult) =>
             snaps.find(({ snapId }) => searchResult.item.snapId === snapId),
           )
-          .filter(Boolean) as IndexSnap[])
+          .filter(Boolean) as Snap[])
       : snaps;
-
-  if (filter.all) {
-    return searchedSnaps;
-  }
 
   const filteredSnaps = filter.installed
     ? searchedSnaps.filter((snap) => Boolean(installedSnaps[snap.snapId]))
@@ -121,61 +111,54 @@ const IndexPage: FunctionComponent<IndexPageProps> = ({ data }) => {
       paddingTop="0"
       marginTop={{ base: 4, md: 20 }}
     >
+      <Box maxWidth="500px" width="100%" marginBottom="8">
+        <Heading as="h2" fontSize="2xl" marginBottom="1">
+          <Trans>Discover Snaps</Trans>
+        </Heading>
+        <Text>
+          <Trans>
+            Explore community-built Snaps to customize your web3 experience via
+            our official directory.{' '}
+            <Link href="https://metamask.io/snaps/" isExternal={true}>
+              Learn more
+            </Link>{' '}
+            and{' '}
+            <Link
+              href="https://support.metamask.io/hc/en-us/articles/18245938714395"
+              isExternal={true}
+            >
+              FAQ
+            </Link>
+            .
+          </Trans>
+        </Text>
+      </Box>
       <Flex
         direction={['column', null, 'row']}
         justifyContent="space-between"
         marginBottom={{ base: 4, md: 6 }}
         gap="4"
       >
-        <Box maxWidth="500px" width="100%">
-          <Heading as="h2" fontSize="2xl" marginBottom="1">
-            <Trans>Discover Snaps</Trans>
-          </Heading>
-          <Text>
-            <Trans>
-              Explore community-built Snaps to customize your web3 experience
-              via our official directory.{' '}
-              <Link href="https://metamask.io/snaps/" isExternal={true}>
-                Learn more
-              </Link>{' '}
-              and{' '}
-              <Link
-                href="https://support.metamask.io/hc/en-us/articles/18245938714395"
-                isExternal={true}
-              >
-                FAQ
-              </Link>
-              .
-            </Trans>
-          </Text>
-        </Box>
-        <Stack
-          direction="row"
-          maxWidth={['100%', null, '400px']}
-          width="100%"
-          marginTop="auto"
-        >
-          <InputGroup background="white" borderRadius="full">
-            <InputLeftElement pointerEvents="none">
-              <Icon icon="search" width="20px" />
-            </InputLeftElement>
-            <Input
-              type="search"
-              borderRadius="full"
-              placeholder={t`Search snaps...`}
-              value={query}
-              onChange={handleChange}
-              border="none"
-              boxShadow="md"
-              _focusVisible={{
-                border: 'none',
-                outline: 'none',
-                boxShadow: 'md',
-              }}
-            />
-          </InputGroup>
-          <FilterMenu />
-        </Stack>
+        <FilterTags />
+        <InputGroup background="white" borderRadius="full" maxWidth="300px">
+          <InputLeftElement pointerEvents="none">
+            <Icon icon="search" width="20px" />
+          </InputLeftElement>
+          <Input
+            type="search"
+            borderRadius="full"
+            placeholder={t`Search snaps...`}
+            value={query}
+            onChange={handleChange}
+            border="none"
+            boxShadow="md"
+            _focusVisible={{
+              border: 'none',
+              outline: 'none',
+              boxShadow: 'md',
+            }}
+          />
+        </InputGroup>
       </Flex>
       <Box>
         <SnapsGrid snaps={snaps} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,7 +19,7 @@ import { useRecoilState } from 'recoil';
 
 import banner from '../assets/images/seo/home.png';
 import type { InstalledSnaps, Snap } from '../components';
-import { Icon, LoadingGrid, FilterTags } from '../components';
+import { Icon, LoadingGrid, FilterTags, FilterMenu } from '../components';
 import { useEthereumProvider, useShuffledSnaps, useFilter } from '../hooks';
 import type { FilterState, RegistrySnapCategory } from '../state';
 import { queryState } from '../state';
@@ -133,14 +133,15 @@ const IndexPage: FunctionComponent<IndexPageProps> = ({ data }) => {
           </Trans>
         </Text>
       </Box>
-      <Flex
-        direction={['column', null, 'row']}
-        justifyContent="space-between"
-        marginBottom={{ base: 4, md: 6 }}
-        gap="4"
-      >
-        <FilterTags />
-        <InputGroup background="white" borderRadius="full" maxWidth="300px">
+      <Flex direction="row" marginBottom={{ base: 4, md: 6 }} gap="2">
+        <FilterMenu />
+        <InputGroup
+          background="white"
+          borderRadius="full"
+          maxWidth={['100%', null, '300px']}
+          marginLeft="auto"
+          order={[2, null, 1]}
+        >
           <InputLeftElement pointerEvents="none">
             <Icon icon="search" width="20px" />
           </InputLeftElement>
@@ -160,6 +161,11 @@ const IndexPage: FunctionComponent<IndexPageProps> = ({ data }) => {
           />
         </InputGroup>
       </Flex>
+      <FilterTags
+        display={['flex', null, 'none']}
+        flexWrap="wrap"
+        marginBottom="6"
+      />
       <Box>
         <SnapsGrid snaps={snaps} />
       </Box>

--- a/src/state.ts
+++ b/src/state.ts
@@ -29,7 +29,6 @@ export const SNAP_CATEGORY_LABELS: Record<
 };
 
 export type FilterState = {
-  all: boolean;
   installed: boolean;
   categories: RegistrySnapCategory[];
 };
@@ -39,7 +38,6 @@ export const INITIAL_CATEGORIES = Object.keys(
 ) as RegistrySnapCategory[];
 
 export const INITIAL_FILTER_STATE: FilterState = {
-  all: true,
   installed: false,
   categories: INITIAL_CATEGORIES,
 };


### PR DESCRIPTION
This pull request adds a list of tags based on the current selected filters. It also restores the filtering behaviour to pre-#111.

I've moved some state into a Recoil atom and selector to reduce state duplication, and remove a workaround using `useEffect` which caused bugs.