### PR TITLE
Show update button when a new version is available

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -11,7 +11,6 @@ import fetch from 'node-fetch';
 import { fetchBuilder, FileSystemCache } from 'node-fetch-cache';
 import path from 'path';
 
-import { SNAPS_REGISTRY_URL } from './src/constants';
 import type { Fields } from './src/utils';
 import { getLatestSnapVersion } from './src/utils';
 import {
@@ -44,6 +43,8 @@ type VerifiedSnap = SnapsRegistryDatabase['verifiedSnaps'][string] & {
     onboard?: boolean;
   };
 };
+
+const REGISTRY_URL = 'https://acl.execution.consensys.io/latest/registry.json';
 
 /**
  * Normalize the description to ensure it ends with a period. This also replaces
@@ -107,13 +108,13 @@ async function getRegistry() {
     new FileSystemCache({ cacheDirectory: fetchCachePath }),
   );
 
-  const registry: SnapsRegistryDatabase = await fetch(SNAPS_REGISTRY_URL, {
+  const registry: SnapsRegistryDatabase = await fetch(REGISTRY_URL, {
     headers,
   }).then(async (response) => response.json());
 
-  const cachedRegistry = await cachedFetch(SNAPS_REGISTRY_URL, {
-    headers,
-  }).then(async (response: any) => response.json());
+  const cachedRegistry = await cachedFetch(REGISTRY_URL, { headers }).then(
+    async (response: any) => response.json(),
+  );
 
   // If the registry has changed, we need to clear the fetch cache to ensure
   // that we get the latest tarballs.

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -11,6 +11,7 @@ import fetch from 'node-fetch';
 import { fetchBuilder, FileSystemCache } from 'node-fetch-cache';
 import path from 'path';
 
+import { SNAPS_REGISTRY_URL } from './src/constants';
 import type { Fields } from './src/utils';
 import { getLatestSnapVersion } from './src/utils';
 import {
@@ -43,8 +44,6 @@ type VerifiedSnap = SnapsRegistryDatabase['verifiedSnaps'][string] & {
     onboard?: boolean;
   };
 };
-
-const REGISTRY_URL = 'https://acl.execution.consensys.io/latest/registry.json';
 
 /**
  * Normalize the description to ensure it ends with a period. This also replaces
@@ -108,13 +107,13 @@ async function getRegistry() {
     new FileSystemCache({ cacheDirectory: fetchCachePath }),
   );
 
-  const registry: SnapsRegistryDatabase = await fetch(REGISTRY_URL, {
+  const registry: SnapsRegistryDatabase = await fetch(SNAPS_REGISTRY_URL, {
     headers,
   }).then(async (response) => response.json());
 
-  const cachedRegistry = await cachedFetch(REGISTRY_URL, { headers }).then(
-    async (response: any) => response.json(),
-  );
+  const cachedRegistry = await cachedFetch(SNAPS_REGISTRY_URL, {
+    headers,
+  }).then(async (response: any) => response.json());
 
   // If the registry has changed, we need to clear the fetch cache to ensure
   // that we get the latest tarballs.

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -10,9 +10,9 @@ import type { RequestInfo, RequestInit } from 'node-fetch';
 import fetch from 'node-fetch';
 import { fetchBuilder, FileSystemCache } from 'node-fetch-cache';
 import path from 'path';
-import semver from 'semver/preload';
 
 import type { Fields } from './src/utils';
+import { getLatestSnapVersion } from './src/utils';
 import {
   generateCategoryImage,
   generateInstalledImage,
@@ -159,16 +159,7 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
       continue;
     }
 
-    const latestVersion = Object.keys(snap.versions).reduce(
-      (result, version) => {
-        if (result === null || semver.gt(version, result)) {
-          return version;
-        }
-
-        return result;
-      },
-    );
-
+    const latestVersion = getLatestSnapVersion(snap);
     const location = detectSnapLocation(snap.id, {
       versionRange: latestVersion as any,
       fetch: customFetch as any,

--- a/src/components/PostInstallModal.tsx
+++ b/src/components/PostInstallModal.tsx
@@ -11,7 +11,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { Trans } from '@lingui/macro';
-import type { FunctionComponent } from 'react';
+import type { FunctionComponent, ReactNode } from 'react';
 
 import { Icon } from './Icon';
 import { SnapIcon } from './SnapIcon';
@@ -23,6 +23,8 @@ export type PostInstallModalProps = {
   name: string;
   icon: string;
   website?: string;
+
+  children: ReactNode;
 };
 
 /**
@@ -41,62 +43,78 @@ function normalizeUrl(value: string): string {
   }
 }
 
+/**
+ * A modal that is shown after a Snap is installed.
+ *
+ * @param props - The component props.
+ * @param props.isOpen - Whether the modal is open.
+ * @param props.onClose - A function to close the modal.
+ * @param props.name - The name of the Snap.
+ * @param props.icon - The icon of the Snap.
+ * @param props.website - The website of the Snap.
+ * @param props.children - The children to render outside of the modal.
+ * @returns A React component.
+ */
 export const PostInstallModal: FunctionComponent<PostInstallModalProps> = ({
   isOpen,
   onClose,
   name,
   icon,
   website,
+  children,
 }) => {
   return (
-    <Modal variant="minimal" size="xs" isOpen={isOpen} onClose={onClose}>
-      <ModalOverlay />
-      <ModalContent>
-        <ModalBody>
-          <Center flexDirection="column">
-            <SnapIcon
-              snapName={name}
-              icon={icon}
-              isInstalled={true}
-              marginBottom="4"
-            />
-            <Heading as="h3" fontSize="lg" marginBottom="4">
-              <Trans>Installation complete</Trans>
-            </Heading>
-            {website ? (
-              <>
-                <Text variant="muted" textAlign="center" marginBottom="4">
-                  <Trans>
-                    Continue to {name}&apos;s website to get started with this
-                    snap.
-                  </Trans>
+    <>
+      <Modal variant="minimal" size="xs" isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalBody>
+            <Center flexDirection="column">
+              <SnapIcon
+                snapName={name}
+                icon={icon}
+                isInstalled={true}
+                marginBottom="4"
+              />
+              <Heading as="h3" fontSize="lg" marginBottom="4">
+                <Trans>Installation complete</Trans>
+              </Heading>
+              {website ? (
+                <>
+                  <Text variant="muted" textAlign="center" marginBottom="4">
+                    <Trans>
+                      Continue to {name}&apos;s website to get started with this
+                      snap.
+                    </Trans>
+                  </Text>
+                  <Link variant="box" href={website} isExternal={true}>
+                    <Flex justifyContent="space-between" alignItems="center">
+                      <Box
+                        as="span"
+                        overflow="hidden"
+                        textOverflow="ellipsis"
+                        whiteSpace="nowrap"
+                      >
+                        {normalizeUrl(website)}
+                      </Box>
+                      <Icon
+                        icon="externalLinkMuted"
+                        marginLeft="2"
+                        width="20px"
+                      />
+                    </Flex>
+                  </Link>
+                </>
+              ) : (
+                <Text variant="muted" textAlign="center">
+                  <Trans>{name} is now ready to use.</Trans>
                 </Text>
-                <Link variant="box" href={website} isExternal={true}>
-                  <Flex justifyContent="space-between" alignItems="center">
-                    <Box
-                      as="span"
-                      overflow="hidden"
-                      textOverflow="ellipsis"
-                      whiteSpace="nowrap"
-                    >
-                      {normalizeUrl(website)}
-                    </Box>
-                    <Icon
-                      icon="externalLinkMuted"
-                      marginLeft="2"
-                      width="20px"
-                    />
-                  </Flex>
-                </Link>
-              </>
-            ) : (
-              <Text variant="muted" textAlign="center">
-                <Trans>{name} is now ready to use.</Trans>
-              </Text>
-            )}
-          </Center>
-        </ModalBody>
-      </ModalContent>
-    </Modal>
+              )}
+            </Center>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+      {children}
+    </>
   );
 };

--- a/src/components/SnapCategory.tsx
+++ b/src/components/SnapCategory.tsx
@@ -3,7 +3,7 @@ import { Trans } from '@lingui/react';
 import type { FunctionComponent } from 'react';
 
 import { SNAP_CATEGORY_LABELS } from '../constants';
-import type { RegistrySnapCategory } from '../features';
+import type { RegistrySnapCategory } from '../constants';
 
 export type SnapCategoryProps = {
   category: RegistrySnapCategory;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,9 +3,6 @@ import { defineMessage } from '@lingui/macro';
 
 import type { IconName } from './components';
 
-export const SNAPS_REGISTRY_URL =
-  'https://acl.execution.consensys.io/latest/registry.json';
-
 export enum RegistrySnapCategory {
   Interoperability = 'interoperability',
   Notifications = 'notifications',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,9 @@ import { defineMessage } from '@lingui/macro';
 
 import type { IconName } from './components';
 
+export const SNAPS_REGISTRY_URL =
+  'https://acl.execution.metamask.io/latest/registry.json';
+
 export enum RegistrySnapCategory {
   Interoperability = 'interoperability',
   Notifications = 'notifications',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,7 @@ import { defineMessage } from '@lingui/macro';
 import type { IconName } from './components';
 
 export const SNAPS_REGISTRY_URL =
-  'https://acl.execution.metamask.io/latest/registry.json';
+  'https://acl.execution.consensys.io/latest/registry.json';
 
 export enum RegistrySnapCategory {
   Interoperability = 'interoperability',

--- a/src/features/filter/components/FilterCategory.tsx
+++ b/src/features/filter/components/FilterCategory.tsx
@@ -6,8 +6,8 @@ import { FilterItem } from './FilterItem';
 import type { IconName } from '../../../components';
 import { Icon } from '../../../components';
 import { SNAP_CATEGORY_LABELS } from '../../../constants';
+import type { RegistrySnapCategory } from '../../../constants';
 import { useDispatch, useSelector } from '../../../hooks';
-import type { RegistrySnapCategory } from '../store';
 import { getCategory, toggleCategory } from '../store';
 
 export type FilterCategoryProps = {

--- a/src/features/filter/components/FilterTag.tsx
+++ b/src/features/filter/components/FilterTag.tsx
@@ -4,8 +4,8 @@ import type { FunctionComponent } from 'react';
 
 import { CloseIcon } from '../../../components';
 import { SNAP_CATEGORY_LABELS } from '../../../constants';
+import type { RegistrySnapCategory } from '../../../constants';
 import { useDispatch } from '../../../hooks';
-import type { RegistrySnapCategory } from '../store';
 import { toggleCategory } from '../store';
 
 export type FilterTagProps = {

--- a/src/features/filter/store.ts
+++ b/src/features/filter/store.ts
@@ -4,7 +4,7 @@ import { createSelector, createSlice } from '@reduxjs/toolkit';
 import { RegistrySnapCategory } from '../../constants';
 import type { ApplicationState } from '../../store';
 import type { Snap } from '../snaps';
-import { snapsApi } from '../snaps';
+import { getInstalledSnaps } from '../snaps';
 
 export type SearchResult = { item: Snap };
 
@@ -115,16 +115,14 @@ export const getCategory = (category: RegistrySnapCategory) =>
 
 export const getFilteredSnaps = createSelector(
   (state: ApplicationState) => state,
-  ({ filter, snaps: snapsState, ...state }) => {
+  (state) => {
+    const { filter, snaps: snapsState } = state;
     const { searchQuery, searchResults, installed, categories } = filter;
     const { snaps } = snapsState;
 
     if (!snaps) {
       return null;
     }
-
-    const { data: installedSnaps = {} } =
-      snapsApi.endpoints.getInstalledSnaps.select(undefined)(state);
 
     const searchedSnaps =
       searchQuery.length > 0
@@ -135,6 +133,7 @@ export const getFilteredSnaps = createSelector(
             .filter(Boolean) as Snap[])
         : snaps;
 
+    const installedSnaps = getInstalledSnaps(state);
     const filteredSnaps = installed
       ? searchedSnaps.filter((snap) => Boolean(installedSnaps[snap.snapId]))
       : searchedSnaps;

--- a/src/features/snaps/store.ts
+++ b/src/features/snaps/store.ts
@@ -65,8 +65,6 @@ export const getUpdateAvailable = (snapId: string) =>
         return false;
       }
 
-      console.log(installedVersion, snap);
-
       return semver.gt(snap.latestVersion, installedVersion);
     },
   );

--- a/src/features/snaps/store.ts
+++ b/src/features/snaps/store.ts
@@ -1,12 +1,21 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSelector, createSlice } from '@reduxjs/toolkit';
+import semver from 'semver/preload';
 
+import { snapsApi } from './api';
 import type { ApplicationState } from '../../store';
 import type { Fields } from '../../utils';
 
 export type Snap = Fields<
   Queries.Snap,
-  'id' | 'snapId' | 'name' | 'summary' | 'icon' | 'category' | 'gatsbyPath'
+  | 'id'
+  | 'snapId'
+  | 'name'
+  | 'summary'
+  | 'icon'
+  | 'category'
+  | 'gatsbyPath'
+  | 'latestVersion'
 >;
 
 export type SnapsState = {
@@ -33,3 +42,31 @@ export const getSnaps = createSelector(
   (state: ApplicationState) => state.snaps,
   ({ snaps }) => snaps,
 );
+
+export const getInstalledSnaps = createSelector(
+  (state: ApplicationState) => state,
+  (state) => snapsApi.endpoints.getInstalledSnaps.select()(state).data ?? {},
+);
+
+export const getUpdateAvailable = (snapId: string) =>
+  createSelector(
+    (state: ApplicationState) => ({
+      installedSnaps: getInstalledSnaps(state),
+      snaps: getSnaps(state),
+    }),
+    ({ installedSnaps, snaps }) => {
+      const installedVersion = installedSnaps?.[snapId]?.version;
+      if (!installedVersion) {
+        return false;
+      }
+
+      const snap = snaps?.find((item) => item.snapId === snapId);
+      if (!snap) {
+        return false;
+      }
+
+      console.log(installedVersion, snap);
+
+      return semver.gt(snap.latestVersion, installedVersion);
+    },
+  );

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -285,6 +285,14 @@ msgstr ""
 msgid "Update required"
 msgstr ""
 
+#: src/components/InstallSnapButton.tsx
+msgid "Update Snap"
+msgstr ""
+
+#: src/components/InstallSnapButton.tsx
+msgid "Updating {name}"
+msgstr ""
+
 #: src/pages/snap/{Snap.location}/{Snap.slug}.tsx
 msgid "Version"
 msgstr ""

--- a/src/utils/snaps.ts
+++ b/src/utils/snaps.ts
@@ -1,4 +1,6 @@
 import type { MetaMaskInpageProvider } from '@metamask/providers';
+import type { SnapsRegistryDatabase } from '@metamask/snaps-registry';
+import semver from 'semver/preload';
 
 export type DeepFields<Type> = Type extends Record<string, unknown>
   ? Fields<Type, keyof Type>
@@ -116,4 +118,26 @@ export async function getSnapsProvider() {
   }
 
   return null;
+}
+
+export type VerifiedSnap = SnapsRegistryDatabase['verifiedSnaps'][string];
+
+/**
+ * Get the latest version of the given Snap.
+ *
+ * @param snap - The Snap to get the latest version for.
+ * @returns The latest version of the Snap.
+ */
+export function getLatestSnapVersion(snap: VerifiedSnap) {
+  const [latest] = Object.keys(snap.versions).sort((a, b) => {
+    return semver.compare(b, a);
+  });
+
+  // This should never happen. The validation in the registry ensures that
+  // there is always at least one version.
+  if (!latest) {
+    throw new Error(`No latest version found for snap: ${snap.id}.`);
+  }
+
+  return latest;
 }


### PR DESCRIPTION
Before this, we show "Installed" when a Snap is installed, regardless of whether there are updates available or not. This adds some logic to check if a new version is available, and if so, show an "Update" button, instead of a non-clickable "Installed" button.