### PR TITLE
Add hover to all buttons

### DIFF
--- a/src/@chakra-ui/gatsby-plugin/theme.js
+++ b/src/@chakra-ui/gatsby-plugin/theme.js
@@ -308,6 +308,12 @@ const theme = extendTheme({
     }),
 
     Button: defineStyleConfig({
+      baseStyle: defineStyle({
+        _hover: {
+          opacity: '0.75',
+        },
+      }),
+
       variants: {
         solid: defineStyle({
           bg: '#24272A',

--- a/src/components/InstallSnapButton.tsx
+++ b/src/components/InstallSnapButton.tsx
@@ -56,7 +56,6 @@ const InstallButton: FunctionComponent<InstallButtonProps> = ({
         loadingText={t`Updating ${name}`}
         onClick={handleInstall}
         width={{ base: '100%', md: 'auto' }}
-        _hover={{ opacity: '75%' }}
       >
         <Trans>Update Snap</Trans>
       </Button>
@@ -84,7 +83,6 @@ const InstallButton: FunctionComponent<InstallButtonProps> = ({
       loadingText={t`Installing ${name}`}
       onClick={handleInstall}
       width={{ base: '100%', md: 'auto' }}
-      _hover={{ opacity: '75%' }}
     >
       <Trans>Add to MetaMask</Trans>
     </Button>

--- a/src/components/InstallUnsupported.tsx
+++ b/src/components/InstallUnsupported.tsx
@@ -23,7 +23,6 @@ export const InstallUnsupported: FunctionComponent = () => {
       variant="primary"
       onClick={onOpen}
       width={{ base: '100%', md: 'auto' }}
-      _hover={{ opacity: '75%' }}
     >
       <Trans>Add to MetaMask</Trans>
     </Button>

--- a/src/components/InstallUnsupportedDesktop.tsx
+++ b/src/components/InstallUnsupportedDesktop.tsx
@@ -52,11 +52,7 @@ export const InstallUnsupportedDesktop: FunctionComponent<
                   href="https://metamask.io/download"
                   isExternal={true}
                 >
-                  <Button
-                    variant="primary"
-                    width="100%"
-                    _hover={{ opacity: '75%' }}
-                  >
+                  <Button variant="primary" width="100%">
                     <Trans>Download MetaMask</Trans>
                   </Button>
                 </Link>

--- a/src/components/InstallUnsupportedDesktopUpdate.tsx
+++ b/src/components/InstallUnsupportedDesktopUpdate.tsx
@@ -25,12 +25,7 @@ export const InstallUnsupportedDesktopUpdate: FunctionComponent<
         </Link>
       </Trans>
     </Text>
-    <Button
-      onClick={onClose}
-      variant="primary"
-      width="100%"
-      _hover={{ opacity: '75%' }}
-    >
+    <Button onClick={onClose} variant="primary" width="100%">
       <Trans>Got it</Trans>
     </Button>
   </>

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -88,7 +88,6 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
                     />
                   }
                   width="100%"
-                  _hover={{ opacity: '75%' }}
                 >
                   <Trans>Website</Trans>
                 </Button>


### PR DESCRIPTION
Previously, only some buttons had a `_hover` property. I've removed all of these properties and moved it to a theme value instead.