### PR TITLE
Fix body background regression

### DIFF
--- a/src/theme/global.ts
+++ b/src/theme/global.ts
@@ -5,6 +5,7 @@ import type { SystemStyleInterpolation } from '@chakra-ui/react';
  */
 export const global: SystemStyleInterpolation = {
   body: {
+    background: 'background.body',
     overflowY: 'scroll',
   },
 };

--- a/src/theme/semantic-tokens.ts
+++ b/src/theme/semantic-tokens.ts
@@ -13,10 +13,6 @@ export type SemanticTokens = {
  */
 export const semanticTokens: SemanticTokens = {
   colors: {
-    'chakra-body-bg': {
-      default: '#F8FAFC',
-      _dark: '#141618',
-    },
     text: {
       default: '#24272A',
       _dark: '#9FA6AE',
@@ -38,6 +34,10 @@ export const semanticTokens: SemanticTokens = {
       },
     },
     background: {
+      body: {
+        default: '#F8FAFC',
+        _dark: '#141618',
+      },
       alternative: { default: '#F5F5F5', _dark: '#1D1F22' },
       hover: {
         default: '#FAFBFC',


### PR DESCRIPTION
For some reason Chakra wasn't applying the `body` background in light mode. Using a different theme key solves this.

To verify, use `yarn build && yarn serve`, and make sure the colour is applied properly.