### PR TITLE
Use theme value for header z-index

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,7 +24,7 @@ export const Header: FunctionComponent<HeaderProps> = (props) => (
     top="0"
     left="0"
     width="100%"
-    zIndex={999999}
+    zIndex="sticky"
   >
     <Container maxWidth="7xl">
       <Stack direction="row" alignItems="center" gap="2">


### PR DESCRIPTION
The header was rendering on top of the modal background (i.e., when a Snap is installed). To fix this, I've changed it to use a proper [theme value for the z-index](https://chakra-ui.com/docs/styled-system/theme#z-index-values).