### PR TITLE
Fix margin around logo on Safari

### DIFF
--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -13,7 +13,7 @@ export const Logo: FunctionComponent = () => {
 
   const fill = colorMode === 'light' ? '#161616' : 'white';
   return (
-    <Box height="1.5rem">
+    <Box width="11.95rem" height="1.5rem">
       <SvgLogo
         width="100%"
         height="100%"


### PR DESCRIPTION
On Safari there was margin around the logo. Forcing the width on the box solves it.