### PR TITLE
Add sort option to filter menu

### DIFF
--- a/src/features/filter/Filter.tsx
+++ b/src/features/filter/Filter.tsx
@@ -10,14 +10,8 @@ import {
   FilterTags,
 } from './components';
 import { FilterOrder } from './components/FilterOrder';
-import { SNAP_CATEGORY_ICONS } from './constants';
-import {
-  filterAll,
-  getAll,
-  getInstalled,
-  Order,
-  toggleInstalled,
-} from './store';
+import { Order, SNAP_CATEGORY_ICONS } from './constants';
+import { filterAll, getAll, getInstalled, toggleInstalled } from './store';
 import type { RegistrySnapCategory } from '../../constants';
 import { SNAP_CATEGORY_LABELS } from '../../constants';
 import { useDispatch, useSelector } from '../../hooks';

--- a/src/features/filter/Filter.tsx
+++ b/src/features/filter/Filter.tsx
@@ -9,8 +9,15 @@ import {
   FilterSearch,
   FilterTags,
 } from './components';
+import { FilterOrder } from './components/FilterOrder';
 import { SNAP_CATEGORY_ICONS } from './constants';
-import { filterAll, getAll, getInstalled, toggleInstalled } from './store';
+import {
+  filterAll,
+  getAll,
+  getInstalled,
+  Order,
+  toggleInstalled,
+} from './store';
 import type { RegistrySnapCategory } from '../../constants';
 import { SNAP_CATEGORY_LABELS } from '../../constants';
 import { useDispatch, useSelector } from '../../hooks';
@@ -59,6 +66,11 @@ export const Filter: FunctionComponent = () => {
                 />
               ),
             )}
+          </MenuGroup>
+          <MenuGroup marginLeft="2" title={t`Sort`}>
+            {Object.values(Order).map((order) => (
+              <FilterOrder key={order} order={order} />
+            ))}
           </MenuGroup>
         </MenuList>
       </Menu>

--- a/src/features/filter/components/FilterOrder.test.tsx
+++ b/src/features/filter/components/FilterOrder.test.tsx
@@ -1,0 +1,37 @@
+import { Menu } from '@chakra-ui/react';
+import { act } from '@testing-library/react';
+
+import { FilterOrder } from './FilterOrder';
+import { createStore } from '../../../store';
+import { render } from '../../../utils/test-utils';
+import { Order } from '../constants';
+import { getOrder } from '../store';
+
+describe('FilterOrder', () => {
+  it('renders', () => {
+    const { queryByText } = render(
+      <Menu>
+        <FilterOrder order={Order.Random} />
+      </Menu>,
+    );
+
+    expect(queryByText('Random')).toBeInTheDocument();
+  });
+
+  it('sets the order when clicked', () => {
+    const store = createStore();
+    const { getByText } = render(
+      <Menu>
+        <FilterOrder order={Order.Alphabetical} />
+      </Menu>,
+      store,
+    );
+
+    expect(getOrder(store.getState())).toBe(Order.Random);
+
+    const button = getByText('Alphabetical');
+    act(() => button.click());
+
+    expect(getOrder(store.getState())).toBe(Order.Alphabetical);
+  });
+});

--- a/src/features/filter/components/FilterOrder.tsx
+++ b/src/features/filter/components/FilterOrder.tsx
@@ -4,8 +4,8 @@ import type { FunctionComponent } from 'react';
 
 import { FilterItem } from './FilterItem';
 import { useDispatch, useSelector } from '../../../hooks';
+import type { Order } from '../constants';
 import { SNAP_ORDER_LABELS } from '../constants';
-import type { Order } from '../store';
 import { getOrder, setOrder } from '../store';
 
 export type FilterOrderProps = {

--- a/src/features/filter/components/FilterOrder.tsx
+++ b/src/features/filter/components/FilterOrder.tsx
@@ -1,0 +1,29 @@
+import { Text } from '@chakra-ui/react';
+import { useLingui } from '@lingui/react';
+import type { FunctionComponent } from 'react';
+
+import { FilterItem } from './FilterItem';
+import { useDispatch, useSelector } from '../../../hooks';
+import { SNAP_ORDER_LABELS } from '../constants';
+import type { Order } from '../store';
+import { getOrder, setOrder } from '../store';
+
+export type FilterOrderProps = {
+  order: Order;
+};
+
+export const FilterOrder: FunctionComponent<FilterOrderProps> = ({ order }) => {
+  const i18n = useLingui();
+  const dispatch = useDispatch();
+  const currentOrder = useSelector(getOrder);
+
+  const handleClick = () => {
+    dispatch(setOrder(order));
+  };
+
+  return (
+    <FilterItem checked={currentOrder === order} onClick={handleClick}>
+      <Text>{i18n._(SNAP_ORDER_LABELS[order])}</Text>
+    </FilterItem>
+  );
+};

--- a/src/features/filter/constants.tsx
+++ b/src/features/filter/constants.tsx
@@ -1,3 +1,6 @@
+import { defineMessage } from '@lingui/macro';
+
+import { Order } from './store';
 import {
   InteroperabilityIcon,
   NotificationsIcon,
@@ -9,4 +12,9 @@ export const SNAP_CATEGORY_ICONS = {
   [RegistrySnapCategory.Interoperability]: InteroperabilityIcon,
   [RegistrySnapCategory.Notifications]: NotificationsIcon,
   [RegistrySnapCategory.TransactionInsights]: TransactionInsightsIcon,
+};
+
+export const SNAP_ORDER_LABELS = {
+  [Order.Random]: defineMessage`Random`,
+  [Order.Alphabetical]: defineMessage`Alphabetical`,
 };

--- a/src/features/filter/constants.tsx
+++ b/src/features/filter/constants.tsx
@@ -1,11 +1,10 @@
 import { defineMessage } from '@lingui/macro';
 
-import { Order } from './store';
 import {
   InteroperabilityIcon,
   NotificationsIcon,
   TransactionInsightsIcon,
-} from '../../components';
+} from '../../components/icons';
 import { RegistrySnapCategory } from '../../constants';
 
 export const SNAP_CATEGORY_ICONS = {
@@ -13,6 +12,11 @@ export const SNAP_CATEGORY_ICONS = {
   [RegistrySnapCategory.Notifications]: NotificationsIcon,
   [RegistrySnapCategory.TransactionInsights]: TransactionInsightsIcon,
 };
+
+export enum Order {
+  Random = 'random',
+  Alphabetical = 'name',
+}
 
 export const SNAP_ORDER_LABELS = {
   [Order.Random]: defineMessage`Random`,

--- a/src/features/filter/store.test.ts
+++ b/src/features/filter/store.test.ts
@@ -1,3 +1,4 @@
+import { Order } from './constants';
 import {
   filterAll,
   filterSlice,
@@ -9,6 +10,7 @@ import {
   getSearchQuery,
   resetSearch,
   setCategory,
+  setOrder,
   setSearchQuery,
   setSearchResults,
   toggleCategory,
@@ -171,6 +173,17 @@ describe('filterSlice', () => {
     });
   });
 
+  describe('setOrder', () => {
+    it('sets the order', () => {
+      const state = filterSlice.reducer(
+        filterSlice.getInitialState(),
+        setOrder(Order.Alphabetical),
+      );
+
+      expect(state.order).toBe(Order.Alphabetical);
+    });
+  });
+
   describe('getSearchQuery', () => {
     it('gets the search query', () => {
       const state = getMockState({
@@ -293,6 +306,7 @@ describe('filterSlice', () => {
           searchResults: [],
           installed: false,
           categories: [],
+          order: Order.Random,
         },
         snaps: {
           snaps: null,
@@ -317,6 +331,7 @@ describe('filterSlice', () => {
             RegistrySnapCategory.Notifications,
             RegistrySnapCategory.TransactionInsights,
           ],
+          order: Order.Random,
         },
         snaps: {
           snaps: [fooSnap, barSnap, bazSnap],
@@ -367,6 +382,7 @@ describe('filterSlice', () => {
             RegistrySnapCategory.Notifications,
             RegistrySnapCategory.TransactionInsights,
           ],
+          order: Order.Random,
         },
         snaps: {
           snaps: [fooSnap, barSnap, bazSnap],
@@ -413,6 +429,7 @@ describe('filterSlice', () => {
             RegistrySnapCategory.Notifications,
             RegistrySnapCategory.TransactionInsights,
           ],
+          order: Order.Random,
         },
         snaps: {
           snaps: [fooSnap, barSnap, bazSnap],
@@ -450,6 +467,7 @@ describe('filterSlice', () => {
             RegistrySnapCategory.Notifications,
             RegistrySnapCategory.TransactionInsights,
           ],
+          order: Order.Random,
         },
         snaps: {
           snaps: [fooSnap, barSnap, bazSnap],
@@ -493,6 +511,7 @@ describe('filterSlice', () => {
             RegistrySnapCategory.Notifications,
             RegistrySnapCategory.TransactionInsights,
           ],
+          order: Order.Random,
         },
         snaps: {
           snaps: [fooSnap, barSnap, bazSnap],
@@ -515,6 +534,59 @@ describe('filterSlice', () => {
       });
 
       expect(getFilteredSnaps(state)).toStrictEqual([fooSnap, bazSnap]);
+    });
+
+    it('sorts the Snaps alphabetically', () => {
+      const { snap: fooSnap } = getMockSnap({
+        snapId: 'foo-snap',
+        name: 'Foo',
+      });
+      const { snap: barSnap } = getMockSnap({
+        snapId: 'bar-snap',
+        name: 'Bar',
+      });
+      const { snap: bazSnap } = getMockSnap({
+        snapId: 'baz-snap',
+        name: 'Baz',
+      });
+
+      const state = getMockState({
+        filter: {
+          searchQuery: '',
+          searchResults: [],
+          installed: false,
+          categories: [
+            RegistrySnapCategory.Interoperability,
+            RegistrySnapCategory.Notifications,
+            RegistrySnapCategory.TransactionInsights,
+          ],
+          order: Order.Alphabetical,
+        },
+        snaps: {
+          snaps: [fooSnap, barSnap, bazSnap],
+        },
+        snapsApi: {
+          queries: {
+            'getInstalledSnaps(undefined)': getMockQueryResponse({
+              [fooSnap.snapId]: {
+                version: fooSnap.latestVersion,
+              },
+              [barSnap.snapId]: {
+                version: barSnap.latestVersion,
+              },
+              [bazSnap.snapId]: {
+                version: bazSnap.latestVersion,
+              },
+            }),
+          },
+        },
+      });
+
+      expect(getFilteredSnaps(state)).toStrictEqual([
+        barSnap,
+        bazSnap,
+        fooSnap,
+      ]);
     });
   });
 });

--- a/src/features/filter/store.ts
+++ b/src/features/filter/store.ts
@@ -1,17 +1,13 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSelector, createSlice } from '@reduxjs/toolkit';
 
+import { Order } from './constants';
 import { RegistrySnapCategory } from '../../constants';
 import type { ApplicationState } from '../../store';
 import type { Snap } from '../snaps';
 import { getInstalledSnaps } from '../snaps';
 
 export type SearchResult = { item: Snap };
-
-export enum Order {
-  Random = 'random',
-  Alphabetical = 'name',
-}
 
 export const SORT_FUNCTIONS = {
   // Snaps are randomly sorted by default, so this is a no-op.

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -42,6 +42,10 @@ msgstr ""
 msgid "All"
 msgstr ""
 
+#: src/features/filter/constants.tsx
+msgid "Alphabetical"
+msgstr ""
+
 #: src/pages/snap/{Snap.location}/{Snap.slug}.tsx
 msgid "Audit"
 msgstr ""
@@ -236,6 +240,10 @@ msgstr ""
 msgid "Privacy Policy"
 msgstr ""
 
+#: src/features/filter/constants.tsx
+msgid "Random"
+msgstr ""
+
 #: src/components/icons/index.ts
 msgid "Search"
 msgstr ""
@@ -250,6 +258,10 @@ msgstr ""
 
 #: src/components/icons/index.ts
 msgid "Snap"
+msgstr ""
+
+#: src/features/filter/Filter.tsx
+msgid "Sort"
 msgstr ""
 
 #: src/pages/snap/{Snap.location}/{Snap.slug}.tsx


### PR DESCRIPTION
This adds a new "Sort" option to the filter menu, which determines how Snaps on the main page are shown. Either in random order (default) or alphabetical.

Closes #144.