### PR TITLE
Implement custom Segment events

### DIFF
--- a/.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch
+++ b/.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch
@@ -1,0 +1,26 @@
+diff --git a/cryptoNode.js b/cryptoNode.js
+index a88676d127194c2bfbd89adf18ff9f707e0a9ae1..892ef63eb438d2b75e0dc23fcd11315cc5333338 100644
+--- a/cryptoNode.js
++++ b/cryptoNode.js
+@@ -5,6 +5,6 @@ exports.crypto = void 0;
+ // See utils.ts for details.
+ // The file will throw on node.js 14 and earlier.
+ // @ts-ignore
+-const nc = require("node:crypto");
++const nc = require("crypto");
+ exports.crypto = nc && typeof nc === 'object' && 'webcrypto' in nc ? nc.webcrypto : undefined;
+ //# sourceMappingURL=cryptoNode.js.map
+\ No newline at end of file
+diff --git a/esm/cryptoNode.js b/esm/cryptoNode.js
+index 241f1da4f8547e83932ed1a9fe3f3907210fc4de..a2f597762817413a040e63c1f01ed5101ad7088a 100644
+--- a/esm/cryptoNode.js
++++ b/esm/cryptoNode.js
+@@ -2,6 +2,6 @@
+ // See utils.ts for details.
+ // The file will throw on node.js 14 and earlier.
+ // @ts-ignore
+-import * as nc from 'node:crypto';
++import * as nc from 'crypto';
+ export const crypto = nc && typeof nc === 'object' && 'webcrypto' in nc ? nc.webcrypto : undefined;
+ //# sourceMappingURL=cryptoNode.js.map
+\ No newline at end of file

--- a/package.json
+++ b/package.json
@@ -41,6 +41,12 @@
     ]
   },
   "resolutions": {
+    "@noble/hashes@1.3.1": "patch:@noble/hashes@npm%3A1.3.2#./.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch",
+    "@noble/hashes@^1.0.0": "patch:@noble/hashes@npm%3A1.3.2#./.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch",
+    "@noble/hashes@^1.3.1": "patch:@noble/hashes@npm%3A1.3.2#./.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch",
+    "@noble/hashes@~1.1.1": "patch:@noble/hashes@npm%3A1.3.2#./.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch",
+    "@noble/hashes@~1.3.0": "patch:@noble/hashes@npm%3A1.3.2#./.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch",
+    "@noble/hashes@~1.3.1": "patch:@noble/hashes@npm%3A1.3.2#./.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch",
     "xml2js": "^0.5.0"
   },
   "dependencies": {
@@ -56,6 +62,7 @@
     "@metamask/logo": "^3.1.1",
     "@metamask/providers": "^13.0.0",
     "@metamask/snaps-controllers": "^2.0.0",
+    "@metamask/utils": "^8.1.0",
     "@reduxjs/toolkit": "^1.9.6",
     "framer-motion": "^10.16.2",
     "gatsby": "^5.12.3",

--- a/src/analytics.test.ts
+++ b/src/analytics.test.ts
@@ -1,0 +1,25 @@
+import { SnapEventType, track } from './analytics';
+
+describe('track', () => {
+  it('tracks the event', () => {
+    const fn = jest.fn();
+
+    // eslint-disable-next-line no-restricted-globals
+    Object.defineProperty(window, 'analytics', {
+      value: {
+        track: fn,
+      },
+    });
+
+    track({
+      type: SnapEventType.Installed,
+      snapId: 'foo',
+      version: '1.0.0',
+    });
+
+    expect(fn).toHaveBeenCalledWith(SnapEventType.Installed, {
+      snapId: 'foo',
+      version: '1.0.0',
+    });
+  });
+});

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -7,11 +7,12 @@ export enum SnapEventType {
   InstallationFailed = 'Snap Installation Failed',
   InstallationRejected = 'Snap Installation Rejected',
   Update = 'Snap Update Clicked',
+  Website = 'Snap Website Clicked',
 }
 
 /**
- * Snap install event, which is tracked when the user clicks the install button
- * for a Snap.
+ * Snap install event, which is triggered when the user clicks the install
+ * button for a Snap.
  */
 export type SnapInstallEvent = {
   type: SnapEventType.Install;
@@ -20,7 +21,7 @@ export type SnapInstallEvent = {
 };
 
 /**
- * Snap installed event, which is tracked when a Snap is installed.
+ * Snap installed event, which is triggered when a Snap is installed.
  */
 export type SnapInstalledEvent = {
   type: SnapEventType.Installed;
@@ -29,7 +30,7 @@ export type SnapInstalledEvent = {
 };
 
 /**
- * Snap installation failed event, which is tracked when a Snap fails to
+ * Snap installation failed event, which is triggered when a Snap fails to
  * install, for any reason.
  */
 export type SnapInstallationFailedEvent = {
@@ -40,7 +41,7 @@ export type SnapInstallationFailedEvent = {
 };
 
 /**
- * Snap installation rejected event, which is tracked when a Snap installation
+ * Snap installation rejected event, which is triggered when a Snap installation
  * is rejected by the user.
  */
 export type SnapInstallationRejectedEvent = {
@@ -50,7 +51,7 @@ export type SnapInstallationRejectedEvent = {
 };
 
 /**
- * Snap update event, which is tracked when the user clicks the update button
+ * Snap update event, which is triggered when the user clicks the update button
  * for a Snap.
  */
 export type SnapUpdateEvent = {
@@ -60,19 +61,38 @@ export type SnapUpdateEvent = {
   newVersion: string;
 };
 
+/**
+ * The origin of the {@link SnapWebsiteEvent}.
+ */
+export enum SnapWebsiteOrigin {
+  Modal = 'modal',
+  Button = 'button',
+}
+
+/**
+ * Snap website event, which is triggered when the user clicks the website
+ * button for a Snap, either in the modal or on the Snap's page.
+ */
+export type SnapWebsiteEvent = {
+  type: SnapEventType.Website;
+  snapId: string;
+  origin: SnapWebsiteOrigin;
+};
+
 export type SnapEvent =
   | SnapInstallEvent
   | SnapInstalledEvent
   | SnapInstallationFailedEvent
   | SnapInstallationRejectedEvent
-  | SnapUpdateEvent;
+  | SnapUpdateEvent
+  | SnapWebsiteEvent;
 
 /**
  * Track Snaps Directory events.
  *
- * @param event - The event to track.
- * @param event.type - The type of event to track.
+ * @param event - The event to trigger.
+ * @param event.type - The type of event to trigger.
  */
 export function track({ type, ...data }: SnapEvent): void {
-  window.analytics.track(type, data);
+  window.analytics?.track(type, data);
 }

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -71,8 +71,8 @@ export type SnapEvent =
  * Track Snaps Directory events.
  *
  * @param event - The event to track.
+ * @param event.type - The type of event to track.
  */
-export function track(event: SnapEvent): void {
-  // TODO: Implement Segment.
-  console.log(event);
+export function track({ type, ...data }: SnapEvent): void {
+  window.analytics.track(type, data);
 }

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,0 +1,78 @@
+/**
+ * All the events that can be tracked.
+ */
+export enum SnapEventType {
+  Install = 'Snap Install Clicked',
+  Installed = 'Snap Installed',
+  InstallationFailed = 'Snap Installation Failed',
+  InstallationRejected = 'Snap Installation Rejected',
+  Update = 'Snap Update Clicked',
+}
+
+/**
+ * Snap install event, which is tracked when the user clicks the install button
+ * for a Snap.
+ */
+export type SnapInstallEvent = {
+  type: SnapEventType.Install;
+  snapId: string;
+  version: string;
+};
+
+/**
+ * Snap installed event, which is tracked when a Snap is installed.
+ */
+export type SnapInstalledEvent = {
+  type: SnapEventType.Installed;
+  snapId: string;
+  version: string;
+};
+
+/**
+ * Snap installation failed event, which is tracked when a Snap fails to
+ * install, for any reason.
+ */
+export type SnapInstallationFailedEvent = {
+  type: SnapEventType.InstallationFailed;
+  snapId: string;
+  version: string;
+  error: string;
+};
+
+/**
+ * Snap installation rejected event, which is tracked when a Snap installation
+ * is rejected by the user.
+ */
+export type SnapInstallationRejectedEvent = {
+  type: SnapEventType.InstallationRejected;
+  snapId: string;
+  version: string;
+};
+
+/**
+ * Snap update event, which is tracked when the user clicks the update button
+ * for a Snap.
+ */
+export type SnapUpdateEvent = {
+  type: SnapEventType.Update;
+  snapId: string;
+  oldVersion: string;
+  newVersion: string;
+};
+
+export type SnapEvent =
+  | SnapInstallEvent
+  | SnapInstalledEvent
+  | SnapInstallationFailedEvent
+  | SnapInstallationRejectedEvent
+  | SnapUpdateEvent;
+
+/**
+ * Track Snaps Directory events.
+ *
+ * @param event - The event to track.
+ */
+export function track(event: SnapEvent): void {
+  // TODO: Implement Segment.
+  console.log(event);
+}

--- a/src/components/InstallSnapButton.test.tsx
+++ b/src/components/InstallSnapButton.test.tsx
@@ -1,11 +1,17 @@
+import { beforeEach } from '@jest/globals';
 import { act } from '@testing-library/react';
 
 import { InstallSnapButton } from './InstallSnapButton';
+import * as analytics from '../analytics';
 import { setSnaps } from '../features';
 import { createStore } from '../store';
 import { getMockSnap, getRequestMethodMock, render } from '../utils/test-utils';
 
 describe('InstallSnapButton', () => {
+  beforeEach(() => {
+    jest.spyOn(analytics, 'track').mockImplementation();
+  });
+
   it('renders', async () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({

--- a/src/components/PostInstallModal.test.tsx
+++ b/src/components/PostInstallModal.test.tsx
@@ -10,6 +10,7 @@ describe('PostInstallModal', () => {
       <PostInstallModal
         isOpen={false}
         onClose={jest.fn()}
+        snapId={snap.snapId}
         name={snap.name}
         icon={snap.icon}
       >
@@ -26,6 +27,7 @@ describe('PostInstallModal', () => {
       <PostInstallModal
         isOpen={true}
         onClose={jest.fn()}
+        snapId={snap.snapId}
         name={snap.name}
         icon={snap.icon}
       >
@@ -34,39 +36,5 @@ describe('PostInstallModal', () => {
     );
 
     expect(queryByText('Installation complete')).toBeInTheDocument();
-  });
-
-  it('normalizes the Snap URL', () => {
-    const { snap } = getMockSnap();
-    const { queryByText } = render(
-      <PostInstallModal
-        isOpen={true}
-        onClose={jest.fn()}
-        name={snap.name}
-        icon={snap.icon}
-        website="https://example.com/foo"
-      >
-        <Text>Foo</Text>
-      </PostInstallModal>,
-    );
-
-    expect(queryByText('example.com/foo')).toBeInTheDocument();
-  });
-
-  it('shows the raw URL if it cannot be parsed', () => {
-    const { snap } = getMockSnap();
-    const { queryByText } = render(
-      <PostInstallModal
-        isOpen={true}
-        onClose={jest.fn()}
-        name={snap.name}
-        icon={snap.icon}
-        website="foo"
-      >
-        <Text>Foo</Text>
-      </PostInstallModal>,
-    );
-
-    expect(queryByText('foo')).toBeInTheDocument();
   });
 });

--- a/src/components/PostInstallModal.tsx
+++ b/src/components/PostInstallModal.tsx
@@ -1,9 +1,6 @@
 import {
-  Box,
   Center,
-  Flex,
   Heading,
-  Link,
   Modal,
   ModalBody,
   ModalContent,
@@ -13,13 +10,14 @@ import {
 import { Trans } from '@lingui/macro';
 import type { FunctionComponent, ReactNode } from 'react';
 
-import { ExternalLinkIcon } from './icons';
+import { PostInstallSnapWebsiteButton } from './PostInstallSnapWebsiteButton';
 import { SnapAvatar } from './SnapAvatar';
 
 export type PostInstallModalProps = {
   isOpen: boolean;
   onClose: () => void;
 
+  snapId: string;
   name: string;
   icon: string;
   website?: string;
@@ -28,27 +26,12 @@ export type PostInstallModalProps = {
 };
 
 /**
- * Normalize a URL to its host and pathname.
- *
- * @param value - The URL to normalize.
- * @returns The normalized URL.
- */
-function normalizeUrl(value: string): string {
-  try {
-    const url = new URL(value);
-    const path = url.pathname === '/' ? '' : url.pathname;
-    return url.host + path;
-  } catch {
-    return value;
-  }
-}
-
-/**
  * A modal that is shown after a Snap is installed.
  *
  * @param props - The component props.
  * @param props.isOpen - Whether the modal is open.
  * @param props.onClose - A function to close the modal.
+ * @param props.snapId - The ID of the Snap.
  * @param props.name - The name of the Snap.
  * @param props.icon - The icon of the Snap.
  * @param props.website - The website of the Snap.
@@ -58,6 +41,7 @@ function normalizeUrl(value: string): string {
 export const PostInstallModal: FunctionComponent<PostInstallModalProps> = ({
   isOpen,
   onClose,
+  snapId,
   name,
   icon,
   website,
@@ -87,20 +71,10 @@ export const PostInstallModal: FunctionComponent<PostInstallModalProps> = ({
                       snap.
                     </Trans>
                   </Text>
-                  <Link variant="box" href={website} isExternal={true}>
-                    <Flex justifyContent="space-between" alignItems="center">
-                      <Box
-                        as="span"
-                        overflow="hidden"
-                        textOverflow="ellipsis"
-                        whiteSpace="nowrap"
-                      >
-                        {normalizeUrl(website)}
-                      </Box>
-                      {/* TODO: Muted icon */}
-                      <ExternalLinkIcon marginLeft="2" width="1.25rem" />
-                    </Flex>
-                  </Link>
+                  <PostInstallSnapWebsiteButton
+                    snapId={snapId}
+                    website={website}
+                  />
                 </>
               ) : (
                 <Text variant="muted" textAlign="center">

--- a/src/components/PostInstallSnapWebsiteButton.test.tsx
+++ b/src/components/PostInstallSnapWebsiteButton.test.tsx
@@ -1,0 +1,60 @@
+import { beforeEach } from '@jest/globals';
+
+import { PostInstallSnapWebsiteButton } from './PostInstallSnapWebsiteButton';
+import * as analytics from '../analytics';
+import { SnapEventType, SnapWebsiteOrigin } from '../analytics';
+import { render } from '../utils/test-utils';
+
+describe('PostInstallSnapWebsiteButton', () => {
+  beforeEach(() => {
+    jest.spyOn(analytics, 'track').mockImplementation();
+  });
+
+  it('renders', () => {
+    const { queryByText } = render(
+      <PostInstallSnapWebsiteButton
+        snapId="test"
+        website="https://example.com"
+      />,
+    );
+
+    expect(queryByText('example.com')).toBeInTheDocument();
+  });
+
+  it('renders with a pathname', () => {
+    const { queryByText } = render(
+      <PostInstallSnapWebsiteButton
+        snapId="test"
+        website="https://example.com/path"
+      />,
+    );
+
+    expect(queryByText('example.com/path')).toBeInTheDocument();
+  });
+
+  it('renders the original URL if the URL is invalid', () => {
+    const { queryByText } = render(
+      <PostInstallSnapWebsiteButton snapId="test" website="invalid" />,
+    );
+
+    expect(queryByText('invalid')).toBeInTheDocument();
+  });
+
+  it('triggers an event when clicked', () => {
+    const { getByText } = render(
+      <PostInstallSnapWebsiteButton
+        snapId="test"
+        website="https://example.com"
+      />,
+    );
+
+    const link = getByText('example.com');
+    link.click();
+
+    expect(analytics.track).toHaveBeenCalledWith({
+      type: SnapEventType.Website,
+      snapId: 'test',
+      origin: SnapWebsiteOrigin.Modal,
+    });
+  });
+});

--- a/src/components/PostInstallSnapWebsiteButton.tsx
+++ b/src/components/PostInstallSnapWebsiteButton.tsx
@@ -1,0 +1,63 @@
+import { Box, Flex, Link } from '@chakra-ui/react';
+import type { FunctionComponent } from 'react';
+
+import { ExternalLinkIcon } from './icons';
+import { SnapEventType, SnapWebsiteOrigin, track } from '../analytics';
+
+export type PostInstallSnapWebsiteButtonProps = {
+  snapId: string;
+  website: string;
+};
+
+/**
+ * Normalize a URL to its host and pathname.
+ *
+ * @param value - The URL to normalize.
+ * @returns The normalized URL.
+ */
+function normalizeUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    const path = url.pathname === '/' ? '' : url.pathname;
+    return url.host + path;
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * The website button for the post-install modal.
+ *
+ * @param props - The component props.
+ * @param props.snapId - The ID of the Snap.
+ * @param props.website - The website of the Snap.
+ * @returns A React component.
+ */
+export const PostInstallSnapWebsiteButton: FunctionComponent<
+  PostInstallSnapWebsiteButtonProps
+> = ({ snapId, website }) => {
+  const handleClick = () => {
+    track({
+      type: SnapEventType.Website,
+      origin: SnapWebsiteOrigin.Modal,
+      snapId,
+    });
+  };
+
+  return (
+    <Link variant="box" href={website} isExternal={true} onClick={handleClick}>
+      <Flex justifyContent="space-between" alignItems="center">
+        <Box
+          as="span"
+          overflow="hidden"
+          textOverflow="ellipsis"
+          whiteSpace="nowrap"
+        >
+          {normalizeUrl(website)}
+        </Box>
+        {/* TODO: Muted icon */}
+        <ExternalLinkIcon marginLeft="2" width="1.25rem" />
+      </Flex>
+    </Link>
+  );
+};

--- a/src/components/SnapWebsiteButton.test.tsx
+++ b/src/components/SnapWebsiteButton.test.tsx
@@ -1,0 +1,35 @@
+import { beforeEach } from '@jest/globals';
+
+import { SnapWebsiteButton } from './SnapWebsiteButton';
+import { SnapEventType, SnapWebsiteOrigin } from '../analytics';
+import * as analytics from '../analytics';
+import { render } from '../utils/test-utils';
+
+describe('SnapWebsiteButton', () => {
+  beforeEach(() => {
+    jest.spyOn(analytics, 'track').mockImplementation();
+  });
+
+  it('renders', () => {
+    const { queryByText } = render(
+      <SnapWebsiteButton snapId="test" website="https://example.com" />,
+    );
+
+    expect(queryByText('Website')).toBeInTheDocument();
+  });
+
+  it('triggers an event when clicked', () => {
+    const { getByText } = render(
+      <SnapWebsiteButton snapId="test" website="https://example.com" />,
+    );
+
+    const link = getByText('Website');
+    link.click();
+
+    expect(analytics.track).toHaveBeenCalledWith({
+      type: SnapEventType.Website,
+      snapId: 'test',
+      origin: SnapWebsiteOrigin.Button,
+    });
+  });
+});

--- a/src/components/SnapWebsiteButton.tsx
+++ b/src/components/SnapWebsiteButton.tsx
@@ -1,0 +1,44 @@
+import { Button, Link } from '@chakra-ui/react';
+import { Trans } from '@lingui/macro';
+import type { FunctionComponent } from 'react';
+
+import { ExternalLinkIcon } from './icons';
+import { SnapEventType, SnapWebsiteOrigin, track } from '../analytics';
+
+export type SnapWebsiteButtonProps = {
+  snapId: string;
+  website: string;
+  onboard?: boolean;
+};
+
+export const SnapWebsiteButton: FunctionComponent<SnapWebsiteButtonProps> = ({
+  snapId,
+  website,
+  onboard,
+}) => {
+  const handleClick = () => {
+    track({
+      type: SnapEventType.Website,
+      origin: SnapWebsiteOrigin.Button,
+      snapId,
+    });
+  };
+
+  return (
+    <Link
+      href={website}
+      isExternal={true}
+      _hover={{ textDecoration: 'none' }}
+      width={{ base: '100%', md: 'auto' }}
+      onClick={handleClick}
+    >
+      <Button
+        variant={onboard ? 'primary' : 'outline'}
+        leftIcon={<ExternalLinkIcon width="1.5rem" fill="currentColor" />}
+        width="100%"
+      >
+        <Trans>Website</Trans>
+      </Button>
+    </Link>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,3 +17,4 @@ export * from './SnapAvatar';
 export * from './SnapAuthorship';
 export * from './SnapSourceCode';
 export * from './SnapsProvider';
+export * from './SnapWebsiteButton';

--- a/src/features/snaps/api.test.ts
+++ b/src/features/snaps/api.test.ts
@@ -1,12 +1,19 @@
 import { act } from 'react-dom/test-utils';
 
 import {
+  getInstalledSnap,
+  getInstalledSnaps,
   useGetInstalledSnapsQuery,
   useGetVersionQuery,
   useInstallSnapMutation,
 } from './api';
+import * as analytics from '../../analytics';
+import { SnapEventType } from '../../analytics';
+import { createStore } from '../../store';
 import {
+  getMockQueryResponse,
   getMockSnap,
+  getMockState,
   getRequestMethodMock,
   renderHook,
 } from '../../utils/test-utils';
@@ -38,7 +45,7 @@ describe('snapsApi', () => {
           /* eslint-disable @typescript-eslint/naming-convention */
           wallet_getSnaps: {
             [snap.snapId]: {
-              version: [snap.latestVersion],
+              version: snap.latestVersion,
             },
           },
           /* eslint-enable @typescript-eslint/naming-convention */
@@ -51,7 +58,7 @@ describe('snapsApi', () => {
 
       expect(result.current.data).toStrictEqual({
         [snap.snapId]: {
-          version: [snap.latestVersion],
+          version: snap.latestVersion,
         },
       });
     });
@@ -153,6 +160,275 @@ describe('snapsApi', () => {
 
       const [, { error }] = result.current;
       expect(error).toStrictEqual(new Error('Failed to install snap.'));
+    });
+
+    it('tracks the install event', async () => {
+      const { snap } = getMockSnap();
+      Object.assign(globalThis, 'window', {
+        ethereum: getRequestMethodMock({
+          /* eslint-disable @typescript-eslint/naming-convention */
+          wallet_requestSnaps: {
+            [snap.snapId]: {
+              error: null,
+            },
+          },
+          /* eslint-enable @typescript-eslint/naming-convention */
+        }),
+      });
+
+      const spy = jest.spyOn(analytics, 'track');
+      const { result } = await act(() =>
+        renderHook(() => useInstallSnapMutation()),
+      );
+
+      const [installSnap] = result.current;
+      await act(
+        async () =>
+          await installSnap({
+            snapId: snap.snapId,
+            version: snap.latestVersion,
+          }),
+      );
+
+      expect(spy).toHaveBeenCalledWith({
+        type: SnapEventType.Install,
+        snapId: snap.snapId,
+        version: snap.latestVersion,
+      });
+
+      expect(spy).toHaveBeenCalledWith({
+        type: SnapEventType.Installed,
+        snapId: snap.snapId,
+        version: snap.latestVersion,
+      });
+    });
+
+    it('tracks the installation failed event for errors in the response', async () => {
+      const { snap } = getMockSnap();
+      Object.assign(globalThis, 'window', {
+        ethereum: getRequestMethodMock({
+          /* eslint-disable @typescript-eslint/naming-convention */
+          wallet_requestSnaps: {
+            [snap.snapId]: {
+              error: 'Install failed.',
+            },
+          },
+          /* eslint-enable @typescript-eslint/naming-convention */
+        }),
+      });
+
+      const spy = jest.spyOn(analytics, 'track');
+      const { result } = await act(() =>
+        renderHook(() => useInstallSnapMutation()),
+      );
+
+      const [installSnap] = result.current;
+      await act(
+        async () =>
+          await installSnap({
+            snapId: snap.snapId,
+            version: snap.latestVersion,
+          }),
+      );
+
+      expect(spy).toHaveBeenCalledWith({
+        type: SnapEventType.Install,
+        snapId: snap.snapId,
+        version: snap.latestVersion,
+      });
+
+      expect(spy).toHaveBeenCalledWith({
+        type: SnapEventType.InstallationFailed,
+        snapId: snap.snapId,
+        version: snap.latestVersion,
+        error: 'Install failed.',
+      });
+    });
+
+    it('tracks the installation failed event for request errors', async () => {
+      const { snap } = getMockSnap();
+      Object.assign(globalThis, 'window', {
+        ethereum: getRequestMethodMock({
+          /* eslint-disable @typescript-eslint/naming-convention */
+          wallet_requestSnaps: new Error('Install failed.'),
+          /* eslint-enable @typescript-eslint/naming-convention */
+        }),
+      });
+
+      const spy = jest.spyOn(analytics, 'track');
+      const { result } = await act(() =>
+        renderHook(() => useInstallSnapMutation()),
+      );
+
+      const [installSnap] = result.current;
+      await act(
+        async () =>
+          await installSnap({
+            snapId: snap.snapId,
+            version: snap.latestVersion,
+          }),
+      );
+
+      expect(spy).toHaveBeenCalledWith({
+        type: SnapEventType.Install,
+        snapId: snap.snapId,
+        version: snap.latestVersion,
+      });
+
+      expect(spy).toHaveBeenCalledWith({
+        type: SnapEventType.InstallationFailed,
+        snapId: snap.snapId,
+        version: snap.latestVersion,
+        error: 'Install failed.',
+      });
+    });
+
+    it('tracks the installation rejected event', async () => {
+      const { snap } = getMockSnap();
+      Object.assign(globalThis, 'window', {
+        ethereum: getRequestMethodMock({
+          /* eslint-disable @typescript-eslint/naming-convention */
+          wallet_requestSnaps: new Error('User rejected the request.'),
+          /* eslint-enable @typescript-eslint/naming-convention */
+        }),
+      });
+
+      const spy = jest.spyOn(analytics, 'track');
+      const { result } = await act(() =>
+        renderHook(() => useInstallSnapMutation()),
+      );
+
+      const [installSnap] = result.current;
+      await act(
+        async () =>
+          await installSnap({
+            snapId: snap.snapId,
+            version: snap.latestVersion,
+          }),
+      );
+
+      expect(spy).toHaveBeenCalledWith({
+        type: SnapEventType.Install,
+        snapId: snap.snapId,
+        version: snap.latestVersion,
+      });
+
+      expect(spy).toHaveBeenCalledWith({
+        type: SnapEventType.InstallationRejected,
+        snapId: snap.snapId,
+        version: snap.latestVersion,
+      });
+    });
+
+    it('tracks the update event', async () => {
+      const { snap } = getMockSnap({ latestVersion: '1.1.0' });
+      Object.assign(globalThis, 'window', {
+        ethereum: getRequestMethodMock({
+          /* eslint-disable @typescript-eslint/naming-convention */
+          wallet_getSnaps: {
+            [snap.snapId]: {
+              version: '1.0.0',
+            },
+          },
+          wallet_requestSnaps: {
+            [snap.snapId]: {
+              error: null,
+            },
+          },
+          /* eslint-enable @typescript-eslint/naming-convention */
+        }),
+      });
+
+      const store = createStore({
+        snaps: {
+          snaps: [snap],
+        },
+      });
+
+      const spy = jest.spyOn(analytics, 'track');
+      const { result } = await act(() =>
+        renderHook(() => useInstallSnapMutation(), store),
+      );
+
+      const [installSnap] = result.current;
+      await act(
+        async () =>
+          await installSnap({
+            snapId: snap.snapId,
+            version: snap.latestVersion,
+          }),
+      );
+
+      expect(spy).toHaveBeenCalledWith({
+        type: SnapEventType.Update,
+        snapId: snap.snapId,
+        oldVersion: '1.0.0',
+        newVersion: '1.1.0',
+      });
+
+      expect(spy).toHaveBeenCalledWith({
+        type: SnapEventType.Installed,
+        snapId: snap.snapId,
+        version: snap.latestVersion,
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    describe('getInstalledSnaps', () => {
+      it('selects the installed Snaps', () => {
+        const { snap } = getMockSnap();
+        const state = getMockState({
+          snapsApi: {
+            queries: {
+              'getInstalledSnaps(undefined)': getMockQueryResponse({
+                [snap.snapId]: {
+                  version: snap.latestVersion,
+                },
+              }),
+            },
+          },
+        });
+
+        expect(getInstalledSnaps(state)).toStrictEqual({
+          [snap.snapId]: {
+            version: snap.latestVersion,
+          },
+        });
+      });
+    });
+
+    describe('getInstalledSnap', () => {
+      it('selects the installed Snap', () => {
+        const { snap } = getMockSnap();
+        const state = getMockState({
+          snapsApi: {
+            queries: {
+              'getInstalledSnaps(undefined)': getMockQueryResponse({
+                [snap.snapId]: {
+                  version: snap.latestVersion,
+                },
+              }),
+            },
+          },
+        });
+
+        expect(getInstalledSnap(snap.snapId)(state)).toStrictEqual({
+          version: snap.latestVersion,
+        });
+      });
+
+      it('returns null if the Snap is not installed', () => {
+        const state = getMockState({
+          snapsApi: {
+            queries: {
+              'getInstalledSnaps(undefined)': getMockQueryResponse({}),
+            },
+          },
+        });
+
+        expect(getInstalledSnap('foo-snap')(state)).toBeNull();
+      });
     });
   });
 });

--- a/src/features/snaps/api.test.ts
+++ b/src/features/snaps/api.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach } from '@jest/globals';
 import { act } from 'react-dom/test-utils';
 
 import {
@@ -19,6 +20,10 @@ import {
 } from '../../utils/test-utils';
 
 describe('snapsApi', () => {
+  beforeEach(() => {
+    jest.spyOn(analytics, 'track').mockImplementation();
+  });
+
   describe('getVersion', () => {
     it('returns the version', async () => {
       Object.assign(globalThis, 'window', {
@@ -176,7 +181,7 @@ describe('snapsApi', () => {
         }),
       });
 
-      const spy = jest.spyOn(analytics, 'track');
+      const spy = jest.spyOn(analytics, 'track').mockImplementation();
       const { result } = await act(() =>
         renderHook(() => useInstallSnapMutation()),
       );
@@ -217,7 +222,7 @@ describe('snapsApi', () => {
         }),
       });
 
-      const spy = jest.spyOn(analytics, 'track');
+      const spy = jest.spyOn(analytics, 'track').mockImplementation();
       const { result } = await act(() =>
         renderHook(() => useInstallSnapMutation()),
       );
@@ -255,7 +260,7 @@ describe('snapsApi', () => {
         }),
       });
 
-      const spy = jest.spyOn(analytics, 'track');
+      const spy = jest.spyOn(analytics, 'track').mockImplementation();
       const { result } = await act(() =>
         renderHook(() => useInstallSnapMutation()),
       );
@@ -293,7 +298,7 @@ describe('snapsApi', () => {
         }),
       });
 
-      const spy = jest.spyOn(analytics, 'track');
+      const spy = jest.spyOn(analytics, 'track').mockImplementation();
       const { result } = await act(() =>
         renderHook(() => useInstallSnapMutation()),
       );
@@ -345,7 +350,7 @@ describe('snapsApi', () => {
         },
       });
 
-      const spy = jest.spyOn(analytics, 'track');
+      const spy = jest.spyOn(analytics, 'track').mockImplementation();
       const { result } = await act(() =>
         renderHook(() => useInstallSnapMutation(), store),
       );

--- a/src/features/snaps/api.ts
+++ b/src/features/snaps/api.ts
@@ -1,6 +1,11 @@
+import { createSelector } from '@reduxjs/toolkit';
 import { createApi } from '@reduxjs/toolkit/query/react';
 
+import { getUpdateAvailable } from './store';
+import { SnapEventType, track } from '../../analytics';
+import type { ApplicationState } from '../../store';
 import { request } from '../../store/api';
+import { getErrorMessage } from '../../utils';
 
 enum SnapsTag {
   InstalledSnaps = 'InstalledSnaps',
@@ -41,13 +46,72 @@ export const snapsApi = createApi({
           },
         },
       }),
-      transformResponse: (snaps: InstallSnapResult, _, { snapId }) => {
+      onQueryStarted({ snapId, version }, api) {
+        const state = api.getState() as ApplicationState;
+        const isUpdate = getUpdateAvailable(snapId)(state);
+
+        if (isUpdate) {
+          const oldVersion =
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            getInstalledSnap(snapId)(state)?.version as string;
+
+          track({
+            type: SnapEventType.Update,
+            snapId,
+            oldVersion,
+            newVersion: version,
+          });
+
+          return;
+        }
+
+        track({
+          type: SnapEventType.Install,
+          snapId,
+          version,
+        });
+      },
+      transformResponse: (snaps: InstallSnapResult, _, { snapId, version }) => {
         const error = snaps[snapId]?.error;
         if (error) {
+          track({
+            type: SnapEventType.InstallationFailed,
+            snapId,
+            version,
+            error: getErrorMessage(error),
+          });
+
           throw new Error(`Failed to install snap: ${error}`);
         }
 
+        track({
+          type: SnapEventType.Installed,
+          snapId,
+          version,
+        });
+
         return snaps;
+      },
+      transformErrorResponse(error, _, { snapId, version }) {
+        const message = getErrorMessage(error);
+        if (message === 'User rejected the request.') {
+          track({
+            type: SnapEventType.InstallationRejected,
+            snapId,
+            version,
+          });
+
+          return error;
+        }
+
+        track({
+          type: SnapEventType.InstallationFailed,
+          snapId,
+          version,
+          error: getErrorMessage(error),
+        });
+
+        return error;
       },
       invalidatesTags: [SnapsTag.InstalledSnaps],
     }),
@@ -59,3 +123,14 @@ export const {
   useGetInstalledSnapsQuery,
   useInstallSnapMutation,
 } = snapsApi;
+
+export const getInstalledSnaps = createSelector(
+  (state: ApplicationState) => state,
+  (state) => snapsApi.endpoints.getInstalledSnaps.select()(state).data ?? {},
+);
+
+export const getInstalledSnap = (snapId: string) =>
+  createSelector(
+    (state: ApplicationState) => getInstalledSnaps(state),
+    (state) => state[snapId] ?? null,
+  );

--- a/src/features/snaps/store.test.ts
+++ b/src/features/snaps/store.test.ts
@@ -1,10 +1,4 @@
-import {
-  getInstalledSnaps,
-  getSnaps,
-  getUpdateAvailable,
-  setSnaps,
-  snapsSlice,
-} from './store';
+import { getSnaps, getUpdateAvailable, setSnaps, snapsSlice } from './store';
 import {
   getMockQueryResponse,
   getMockSnap,
@@ -34,29 +28,6 @@ describe('snapsSlice', () => {
       });
 
       expect(getSnaps(state)).toStrictEqual([getMockSnap().snap]);
-    });
-  });
-
-  describe('getInstalledSnaps', () => {
-    it('selects the installed snaps', () => {
-      const { snap } = getMockSnap();
-      const state = getMockState({
-        snapsApi: {
-          queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
-              [snap.snapId]: {
-                version: snap.latestVersion,
-              },
-            }),
-          },
-        },
-      });
-
-      expect(getInstalledSnaps(state)).toStrictEqual({
-        [snap.snapId]: {
-          version: snap.latestVersion,
-        },
-      });
     });
   });
 

--- a/src/features/snaps/store.ts
+++ b/src/features/snaps/store.ts
@@ -2,7 +2,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSelector, createSlice } from '@reduxjs/toolkit';
 import semver from 'semver/preload';
 
-import { snapsApi } from './api';
+import { getInstalledSnaps } from './api';
 import type { ApplicationState } from '../../store';
 import type { Fields } from '../../utils';
 
@@ -41,11 +41,6 @@ export const { setSnaps } = snapsSlice.actions;
 export const getSnaps = createSelector(
   (state: ApplicationState) => state.snaps,
   ({ snaps }) => snaps,
-);
-
-export const getInstalledSnaps = createSelector(
-  (state: ApplicationState) => state,
-  (state) => snapsApi.endpoints.getInstalledSnaps.select()(state).data ?? {},
 );
 
 export const getUpdateAvailable = (snapId: string) =>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -314,7 +314,7 @@ msgid "Version"
 msgstr ""
 
 #: src/components/FooterLinks.tsx
-#: src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+#: src/components/SnapWebsiteButton.tsx
 msgid "Website"
 msgstr ""
 

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -64,7 +64,7 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
             width={{ base: '100%', md: 'auto' }}
             gap={{ base: 4, md: 4 }}
           >
-            {data.snap.website && (
+            {website && (
               <SnapWebsiteButton
                 snapId={snapId}
                 website={website}

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Button,
-  Container,
-  Divider,
-  Flex,
-  Link,
-  Text,
-} from '@chakra-ui/react';
+import { Box, Container, Divider, Flex, Text } from '@chakra-ui/react';
 import { t, Trans } from '@lingui/macro';
 import { graphql } from 'gatsby';
 import type { FunctionComponent } from 'react';
@@ -20,7 +12,7 @@ import {
   SnapCategory,
   BackButton,
   SnapDescription,
-  ExternalLinkIcon,
+  SnapWebsiteButton,
 } from '../../../components';
 import { ExternalLink } from '../../../components/ExternalLink';
 import type { RegistrySnapCategory } from '../../../constants';
@@ -73,26 +65,11 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
             gap={{ base: 4, md: 4 }}
           >
             {data.snap.website && (
-              <Link
-                href={data.snap.website}
-                isExternal={true}
-                _hover={{ textDecoration: 'none' }}
-                width={{ base: '100%', md: 'auto' }}
-              >
-                <Button
-                  variant={onboard ? 'primary' : 'outline'}
-                  leftIcon={
-                    <ExternalLinkIcon
-                      // icon={onboard ? 'externalLinkInverted' : 'externalLink'}
-                      width="1.5rem"
-                      fill="currentColor"
-                    />
-                  }
-                  width="100%"
-                >
-                  <Trans>Website</Trans>
-                </Button>
-              </Link>
+              <SnapWebsiteButton
+                snapId={snapId}
+                website={website}
+                onboard={onboard}
+              />
             )}
             {!onboard && (
               <InstallSnapButton

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,5 +1,7 @@
 import type { MetaMaskInpageProvider } from '@metamask/providers';
 
+import type { SnapEventType } from '../analytics';
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Window {
@@ -7,6 +9,10 @@ declare global {
       setProvider?: (provider: MetaMaskInpageProvider) => void;
       detected?: MetaMaskInpageProvider[];
       providers?: MetaMaskInpageProvider[];
+    };
+
+    analytics: {
+      track: (event: SnapEventType, data: unknown) => void;
     };
   }
 }

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -1,0 +1,44 @@
+import { formatErrorMessage, getErrorMessage, hasProperty } from './errors';
+
+describe('formatErrorMessage', () => {
+  it('capitalizes the first letter of the message', () => {
+    expect(formatErrorMessage('foo')).toBe('Foo.');
+  });
+
+  it('adds a period at the end if the message does not have one', () => {
+    expect(formatErrorMessage('foo')).toBe('Foo.');
+    expect(formatErrorMessage('foo.')).toBe('Foo.');
+  });
+});
+
+describe('hasProperty', () => {
+  it('returns true if the object has the property', () => {
+    expect(hasProperty({ foo: 'bar' }, 'foo')).toBe(true);
+  });
+
+  it('returns false if the object does not have the property', () => {
+    expect(hasProperty({ foo: 'bar' }, 'bar')).toBe(false);
+  });
+});
+
+describe('getErrorMessage', () => {
+  it('returns the message if the error is an object with a message property', () => {
+    expect(getErrorMessage({ message: 'foo' })).toBe('Foo.');
+  });
+
+  it('returns the error converted to a string if the error is not an object with a message property', () => {
+    expect(getErrorMessage('foo')).toBe('Foo.');
+  });
+
+  it('returns the error converted to a string if the error is null', () => {
+    expect(getErrorMessage(null)).toBe('Null.');
+  });
+
+  it('returns the error converted to a string if the error is undefined', () => {
+    expect(getErrorMessage(undefined)).toBe('Undefined.');
+  });
+
+  it('returns the error converted to a string if the error is a number', () => {
+    expect(getErrorMessage(42)).toBe('42.');
+  });
+});

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -1,4 +1,4 @@
-import { formatErrorMessage, getErrorMessage, hasProperty } from './errors';
+import { formatErrorMessage, getErrorMessage } from './errors';
 
 describe('formatErrorMessage', () => {
   it('capitalizes the first letter of the message', () => {
@@ -8,16 +8,6 @@ describe('formatErrorMessage', () => {
   it('adds a period at the end if the message does not have one', () => {
     expect(formatErrorMessage('foo')).toBe('Foo.');
     expect(formatErrorMessage('foo.')).toBe('Foo.');
-  });
-});
-
-describe('hasProperty', () => {
-  it('returns true if the object has the property', () => {
-    expect(hasProperty({ foo: 'bar' }, 'foo')).toBe(true);
-  });
-
-  it('returns false if the object does not have the property', () => {
-    expect(hasProperty({ foo: 'bar' }, 'bar')).toBe(false);
   });
 });
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,52 @@
+/**
+ * Format an error message. This function capitalizes the first letter of the
+ * message and adds a period at the end if it doesn't already have one.
+ *
+ * @param message - The error message to format.
+ * @returns The formatted error message.
+ */
+export function formatErrorMessage(message: string) {
+  const capitalizedMessage = message.charAt(0).toUpperCase() + message.slice(1);
+
+  if (!message.endsWith('.')) {
+    return `${capitalizedMessage}.`;
+  }
+
+  return capitalizedMessage;
+}
+
+/**
+ * Check if an object has a property.
+ *
+ * @param object - The object to check.
+ * @param property - The property to check for.
+ * @returns Whether the object has the property.
+ */
+export function hasProperty<Type extends object, Property extends string>(
+  object: Type,
+  property: Property,
+): object is Type & Record<Property, unknown> {
+  return Object.prototype.hasOwnProperty.call(object, property);
+}
+
+/**
+ * Get the error message from an unknown error type.
+ *
+ * - If the error is an object with a `message` property, return the message.
+ * - Otherwise, return the error converted to a string.
+ *
+ * @param error - The error to get the message from.
+ * @returns The error message.
+ */
+export function getErrorMessage(error: unknown) {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    hasProperty(error, 'message') &&
+    typeof error.message === 'string'
+  ) {
+    return formatErrorMessage(error.message);
+  }
+
+  return formatErrorMessage(String(error));
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,5 @@
+import { hasProperty, isObject } from '@metamask/utils';
+
 /**
  * Format an error message. This function capitalizes the first letter of the
  * message and adds a period at the end if it doesn't already have one.
@@ -16,20 +18,6 @@ export function formatErrorMessage(message: string) {
 }
 
 /**
- * Check if an object has a property.
- *
- * @param object - The object to check.
- * @param property - The property to check for.
- * @returns Whether the object has the property.
- */
-export function hasProperty<Type extends object, Property extends string>(
-  object: Type,
-  property: Property,
-): object is Type & Record<Property, unknown> {
-  return Object.prototype.hasOwnProperty.call(object, property);
-}
-
-/**
  * Get the error message from an unknown error type.
  *
  * - If the error is an object with a `message` property, return the message.
@@ -40,8 +28,7 @@ export function hasProperty<Type extends object, Property extends string>(
  */
 export function getErrorMessage(error: unknown) {
   if (
-    typeof error === 'object' &&
-    error !== null &&
+    isObject(error) &&
     hasProperty(error, 'message') &&
     typeof error.message === 'string'
   ) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './errors';
 export * from './links';
 export * from './snaps';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5096,6 +5096,7 @@ __metadata:
     "@metamask/snaps-controllers": ^2.0.0
     "@metamask/snaps-registry": ^2.0.0
     "@metamask/snaps-utils": ^2.0.0
+    "@metamask/utils": ^8.1.0
     "@reduxjs/toolkit": ^1.9.6
     "@svgr/webpack": ^8.1.0
     "@testing-library/jest-dom": ^6.1.3
@@ -5352,24 +5353,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@noble/hashes@npm:1.3.1"
-  checksum: 7fdefc0f7a0c1ec27acc6ff88841793e3f93ec4ce6b8a6a12bfc0dd70ae6b7c4c82fe305fdfeda1735d5ad4a9eebe761e6693b3d355689c559e91242f4bc95b1
-  languageName: node
-  linkType: hard
-
-"@noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:~1.3.0, @noble/hashes@npm:~1.3.1":
+"@noble/hashes@npm:1.3.2":
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
   checksum: fe23536b436539d13f90e4b9be843cc63b1b17666a07634a2b1259dded6f490be3d050249e6af98076ea8f2ea0d56f578773c2197f2aa0eeaa5fba5bc18ba474
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:~1.1.1":
-  version: 1.1.5
-  resolution: "@noble/hashes@npm:1.1.5"
-  checksum: de3f095a7ac1cbf5b4b3d09f193288d4f2eec35fbadf2ed9fd7e47d8a3042fef410052ba62dc0296a185f994c11192f5357fdb1bd9178c905efd82e946c53b00
+"@noble/hashes@patch:@noble/hashes@npm%3A1.3.2#./.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch::locator=%40metamask%2Fsnaps-directory%40workspace%3A.":
+  version: 1.3.2
+  resolution: "@noble/hashes@patch:@noble/hashes@npm%3A1.3.2#./.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch::version=1.3.2&hash=3bec85&locator=%40metamask%2Fsnaps-directory%40workspace%3A."
+  checksum: af760f0c6aa312e66f72288a0d464d9d2e7612f5c543c46cbf4b97af04ac9b97ac5afe07f97678536b059c90d1f6a10adcde663b40ce114d7115f8b9dce21e91
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This implements custom events for Segment. Right now the following events are supported:

- `Snap Install Clicked`: When the user clicks on the "Add to MetaMask" button.
- `Snap Installed`: When a Snap is installed (or updated) without errors.
- `Snap Installation Failed`: When a Snap failed installation for an unknown reason.
- `Snap Installation Rejected`: When the user rejected the Snap installation.
- `Snap Update Clicked`: When the user clicks on the "Update Snap" button.
- `Snap Website Clicked`: When the user clicks on the Snap website (either in the installation modal, or on the Snap page).