### PR TITLE
Sort by popularity as default

### DIFF
--- a/src/features/filter/Filter.tsx
+++ b/src/features/filter/Filter.tsx
@@ -62,9 +62,11 @@ export const Filter: FunctionComponent = () => {
             )}
           </MenuGroup>
           <MenuGroup marginLeft="2" title={t`Sort`}>
-            {Object.values(Order).map((order) => (
-              <FilterOrder key={order} order={order} />
-            ))}
+            {Object.values(Order)
+              .filter((order) => order !== Order.Random)
+              .map((order) => (
+                <FilterOrder key={order} order={order} />
+              ))}
           </MenuGroup>
         </MenuList>
       </Menu>

--- a/src/features/filter/Filter.tsx
+++ b/src/features/filter/Filter.tsx
@@ -62,11 +62,9 @@ export const Filter: FunctionComponent = () => {
             )}
           </MenuGroup>
           <MenuGroup marginLeft="2" title={t`Sort`}>
-            {Object.values(Order)
-              .filter((order) => order !== Order.Random)
-              .map((order) => (
-                <FilterOrder key={order} order={order} />
-              ))}
+            {Object.values(Order).map((order) => (
+              <FilterOrder key={order} order={order} />
+            ))}
           </MenuGroup>
         </MenuList>
       </Menu>

--- a/src/features/filter/components/FilterOrder.test.tsx
+++ b/src/features/filter/components/FilterOrder.test.tsx
@@ -27,7 +27,7 @@ describe('FilterOrder', () => {
       store,
     );
 
-    expect(getOrder(store.getState())).toBe(Order.Random);
+    expect(getOrder(store.getState())).toBe(Order.Popularity);
 
     const button = getByText('Alphabetical');
     act(() => button.click());

--- a/src/features/filter/components/FilterOrder.test.tsx
+++ b/src/features/filter/components/FilterOrder.test.tsx
@@ -11,11 +11,11 @@ describe('FilterOrder', () => {
   it('renders', () => {
     const { queryByText } = render(
       <Menu>
-        <FilterOrder order={Order.Random} />
+        <FilterOrder order={Order.Popularity} />
       </Menu>,
     );
 
-    expect(queryByText('Random')).toBeInTheDocument();
+    expect(queryByText('Popularity')).toBeInTheDocument();
   });
 
   it('sets the order when clicked', () => {

--- a/src/features/filter/constants.tsx
+++ b/src/features/filter/constants.tsx
@@ -14,9 +14,9 @@ export const SNAP_CATEGORY_ICONS = {
 };
 
 export enum Order {
+  Popularity = 'popularity',
   Random = 'random',
   Alphabetical = 'name',
-  Popularity = 'popularity',
 }
 
 export const SNAP_ORDER_LABELS = {

--- a/src/features/filter/constants.tsx
+++ b/src/features/filter/constants.tsx
@@ -15,12 +15,10 @@ export const SNAP_CATEGORY_ICONS = {
 
 export enum Order {
   Popularity = 'popularity',
-  Random = 'random',
   Alphabetical = 'name',
 }
 
 export const SNAP_ORDER_LABELS = {
-  [Order.Random]: defineMessage`Random`,
   [Order.Alphabetical]: defineMessage`Alphabetical`,
   [Order.Popularity]: defineMessage`Popularity`,
 };

--- a/src/features/filter/store.test.ts
+++ b/src/features/filter/store.test.ts
@@ -306,7 +306,7 @@ describe('filterSlice', () => {
           searchResults: [],
           installed: false,
           categories: [],
-          order: Order.Random,
+          order: Order.Popularity,
         },
         snaps: {
           snaps: null,
@@ -331,7 +331,7 @@ describe('filterSlice', () => {
             RegistrySnapCategory.Notifications,
             RegistrySnapCategory.TransactionInsights,
           ],
-          order: Order.Random,
+          order: Order.Popularity,
         },
         snaps: {
           snaps: [fooSnap, barSnap, bazSnap],
@@ -382,7 +382,7 @@ describe('filterSlice', () => {
             RegistrySnapCategory.Notifications,
             RegistrySnapCategory.TransactionInsights,
           ],
-          order: Order.Random,
+          order: Order.Popularity,
         },
         snaps: {
           snaps: [fooSnap, barSnap, bazSnap],
@@ -429,7 +429,7 @@ describe('filterSlice', () => {
             RegistrySnapCategory.Notifications,
             RegistrySnapCategory.TransactionInsights,
           ],
-          order: Order.Random,
+          order: Order.Popularity,
         },
         snaps: {
           snaps: [fooSnap, barSnap, bazSnap],
@@ -467,7 +467,7 @@ describe('filterSlice', () => {
             RegistrySnapCategory.Notifications,
             RegistrySnapCategory.TransactionInsights,
           ],
-          order: Order.Random,
+          order: Order.Popularity,
         },
         snaps: {
           snaps: [fooSnap, barSnap, bazSnap],
@@ -511,7 +511,7 @@ describe('filterSlice', () => {
             RegistrySnapCategory.Notifications,
             RegistrySnapCategory.TransactionInsights,
           ],
-          order: Order.Random,
+          order: Order.Popularity,
         },
         snaps: {
           snaps: [fooSnap, barSnap, bazSnap],

--- a/src/features/filter/store.ts
+++ b/src/features/filter/store.ts
@@ -10,9 +10,6 @@ import { getInstalledSnaps } from '../snaps';
 export type SearchResult = { item: Snap };
 
 export const SORT_FUNCTIONS = {
-  // Snaps are randomly sorted by default, so this is a no-op.
-  [Order.Random]: (snaps: Snap[]) => snaps,
-
   [Order.Alphabetical]: (snaps: Snap[]) =>
     snaps.concat().sort((a, b) => a.name.localeCompare(b.name)),
 

--- a/src/features/filter/store.ts
+++ b/src/features/filter/store.ts
@@ -37,7 +37,7 @@ const initialState: FilterState = {
   searchResults: [],
   installed: false,
   categories: INITIAL_CATEGORIES,
-  order: Order.Random,
+  order: Order.Popularity,
 };
 
 export const filterSlice = createSlice({

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -252,10 +252,6 @@ msgstr ""
 msgid "Privacy Policy"
 msgstr ""
 
-#: src/features/filter/constants.tsx
-msgid "Random"
-msgstr ""
-
 #: src/components/icons/index.ts
 msgid "Search"
 msgstr ""


### PR DESCRIPTION
Sort by popularity as default as an experiment. Also disables random ordering in the menu for now too.