### PR TITLE
Bump `sharp`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20154,8 +20154,8 @@ __metadata:
   linkType: hard
 
 "sharp@npm:^0.32.1, sharp@npm:^0.32.5":
-  version: 0.32.5
-  resolution: "sharp@npm:0.32.5"
+  version: 0.32.6
+  resolution: "sharp@npm:0.32.6"
   dependencies:
     color: ^4.2.3
     detect-libc: ^2.0.2
@@ -20166,7 +20166,7 @@ __metadata:
     simple-get: ^4.0.1
     tar-fs: ^3.0.4
     tunnel-agent: ^0.6.0
-  checksum: 3cd6dc037c9ba126a30af90ac94043c4418bbb4228e15fd446638ff43fc9b14eabb553037988e484162c318f7baff21d896a5bef7dcc453f608e247d468f41e0
+  checksum: 0cca1d16b1920800c0e22d27bc6305f4c67c9ebe44f67daceb30bf645ae39e7fb7dfbd7f5d6cd9f9eebfddd87ac3f7e2695f4eb906d19b7a775286238e6a29fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump `sharp` to address https://github.com/MetaMask/snaps-directory/security/dependabot/6

Dependabot failed to make this PR itself.