### PR TITLE
Publish staging site to separate repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,22 @@ jobs:
     name: Build, lint, and test
     uses: ./.github/workflows/build-lint-test.yml
 
+  publish-staging-pr:
+    name: Publish pull request staging site
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/publish-staging.yml
+    with:
+      destination_dir: pr/${{ github.event.pull_request.number }}
+    secrets:
+      PUBLISH_STAGING_PAGES_TOKEN: ${{ secrets.PUBLISH_STAGING_PAGES_TOKEN }}
+
   all-jobs-completed:
     name: All jobs completed
     runs-on: ubuntu-latest
     needs:
       - check-workflows
       - build-lint-test
+      - publish-staging-pr
     outputs:
       PASSED: ${{ steps.set-output.outputs.PASSED }}
     steps:
@@ -48,6 +58,15 @@ jobs:
           if [[ $passed != "true" ]]; then
             exit 1
           fi
+
+  publish-staging-main:
+    name: Publish main staging site
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/publish-staging.yml
+    with:
+      destination_dir: main
+    secrets:
+      PUBLISH_STAGING_PAGES_TOKEN: ${{ secrets.PUBLISH_STAGING_PAGES_TOKEN }}
 
   is-release:
     # Filtering by `push` events ensures that we only release from the `main` branch, which is a

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,9 @@ jobs:
   publish-staging:
     name: Publish staging site
     uses: ./.github/workflows/publish-staging.yml
+    permissions:
+      contents: read
+      pull-requests: write
     secrets:
       PUBLISH_STAGING_PAGES_TOKEN: ${{ secrets.PUBLISH_STAGING_PAGES_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,9 @@ jobs:
     name: Build, lint, and test
     uses: ./.github/workflows/build-lint-test.yml
 
-  publish-staging-pr:
-    name: Publish pull request staging site
-    if: github.event_name == 'pull_request'
+  publish-staging:
+    name: Publish staging site
     uses: ./.github/workflows/publish-staging.yml
-    with:
-      destination_dir: pr/${{ github.event.pull_request.number }}
     secrets:
       PUBLISH_STAGING_PAGES_TOKEN: ${{ secrets.PUBLISH_STAGING_PAGES_TOKEN }}
 
@@ -38,7 +35,7 @@ jobs:
     needs:
       - check-workflows
       - build-lint-test
-      - publish-staging-pr
+      - publish-staging
     outputs:
       PASSED: ${{ steps.set-output.outputs.PASSED }}
     steps:
@@ -58,15 +55,6 @@ jobs:
           if [[ $passed != "true" ]]; then
             exit 1
           fi
-
-  publish-staging-main:
-    name: Publish main staging site
-    if: github.event_name == 'push'
-    uses: ./.github/workflows/publish-staging.yml
-    with:
-      destination_dir: main
-    secrets:
-      PUBLISH_STAGING_PAGES_TOKEN: ${{ secrets.PUBLISH_STAGING_PAGES_TOKEN }}
 
   is-release:
     # Filtering by `push` events ensures that we only release from the `main` branch, which is a

--- a/.github/workflows/publish-staging-site.yml
+++ b/.github/workflows/publish-staging-site.yml
@@ -1,0 +1,50 @@
+name: Publish staging site to GitHub Pages
+
+on:
+  workflow_call:
+    inputs:
+      destination_dir:
+        required: true
+        type: string
+      ref:
+        required: false
+        type: string
+    secrets:
+      PUBLISH_STAGING_PAGES_TOKEN:
+        required: true
+
+jobs:
+  publish-site-to-gh-pages:
+    name: Publish staging site to GitHub Pages
+    runs-on: ubuntu-latest
+    environment: github-pages
+    permissions:
+      contents: write
+    steps:
+      - name: Ensure `destination_dir` is not empty
+        if: ${{ inputs.destination_dir == '' }}
+        run: exit 1
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - name: Install npm dependencies
+        run: yarn --immutable
+      - name: Run build script
+        run: yarn build
+        env:
+          STAGING: true
+          STAGING_PATH_PREFIX: snaps-directory-staging/${{ inputs.destination_dir }}
+          PREFIX_PATHS: true
+      - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
+        with:
+          personal_token: ${{ secrets.PUBLISH_STAGING_PAGES_TOKEN }}
+          external_repository: MetaMask/snaps-directory-staging
+          publish_dir: ./public
+          destination_dir: ${{ inputs.destination_dir }}

--- a/.github/workflows/publish-staging-site.yml
+++ b/.github/workflows/publish-staging-site.yml
@@ -17,7 +17,6 @@ jobs:
   publish-site-to-gh-pages:
     name: Publish staging site to GitHub Pages
     runs-on: ubuntu-latest
-    environment: github-pages
     steps:
       - name: Ensure `destination_dir` is not empty
         if: ${{ inputs.destination_dir == '' }}

--- a/.github/workflows/publish-staging-site.yml
+++ b/.github/workflows/publish-staging-site.yml
@@ -18,8 +18,6 @@ jobs:
     name: Publish staging site to GitHub Pages
     runs-on: ubuntu-latest
     environment: github-pages
-    permissions:
-      contents: write
     steps:
       - name: Ensure `destination_dir` is not empty
         if: ${{ inputs.destination_dir == '' }}

--- a/.github/workflows/publish-staging-site.yml
+++ b/.github/workflows/publish-staging-site.yml
@@ -43,5 +43,6 @@ jobs:
         with:
           personal_token: ${{ secrets.PUBLISH_STAGING_PAGES_TOKEN }}
           external_repository: MetaMask/snaps-directory-staging
+          publish_branch: main
           publish_dir: ./public
           destination_dir: ${{ inputs.destination_dir }}

--- a/.github/workflows/publish-staging-site.yml
+++ b/.github/workflows/publish-staging-site.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   publish-site-to-gh-pages:
     name: Publish staging site to GitHub Pages
+    environment: staging
     runs-on: ubuntu-latest
     steps:
       - name: Ensure `destination_dir` is not empty

--- a/.github/workflows/publish-staging-site.yml
+++ b/.github/workflows/publish-staging-site.yml
@@ -6,9 +6,6 @@ on:
       destination_dir:
         required: true
         type: string
-      ref:
-        required: false
-        type: string
     secrets:
       PUBLISH_STAGING_PAGES_TOKEN:
         required: true
@@ -23,8 +20,6 @@ jobs:
         run: exit 1
       - name: Checkout the repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.ref || github.sha }}
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,50 +1,46 @@
-name: Publish staging site to GitHub Pages
+name: Publish staging site
 
 on:
   workflow_call:
-    inputs:
-      destination_dir:
-        required: true
-        type: string
-      ref:
-        required: false
-        type: string
     secrets:
       PUBLISH_STAGING_PAGES_TOKEN:
         required: true
 
 jobs:
-  publish-site-to-gh-pages:
-    name: Publish staging site to GitHub Pages
+  publish-pull-request:
+    name: Publish pull request
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/publish-staging-site.yml
+    with:
+      destination_dir: pr/${{ github.event.pull_request.number }}
+    secrets:
+      PUBLISH_STAGING_PAGES_TOKEN: ${{ secrets.PUBLISH_STAGING_PAGES_TOKEN }}
+
+  comment-on-pull-request:
+    name: Comment on pull request with link to site
     runs-on: ubuntu-latest
-    environment: github-pages
+    needs: publish-pull-request
     permissions:
-      contents: write
+      contents: read
+      pull-requests: write
     steps:
-      - name: Ensure `destination_dir` is not empty
-        if: ${{ inputs.destination_dir == '' }}
-        run: exit 1
-      - name: Checkout the repository
-        uses: actions/checkout@v3
+      - name: Comment on pull request
+        uses: actions/github-script@v6
         with:
-          ref: ${{ inputs.ref || github.sha }}
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - name: Install npm dependencies
-        run: yarn --immutable
-      - name: Run build script
-        run: yarn build
-        env:
-          STAGING: true
-          STAGING_PATH_PREFIX: snaps-directory-staging/${{ inputs.destination_dir }}
-          PREFIX_PATHS: true
-      - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
-        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
-        with:
-          personal_token: ${{ secrets.PUBLISH_STAGING_PAGES_TOKEN }}
-          external_repository: MetaMask/snaps-directory-staging
-          publish_dir: ./public
-          destination_dir: ${{ inputs.destination_dir }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Staging website successfully published:\n\nhttps://metamask.github.io/snaps-directory-staging/pr/${context.issue.number}/`,
+            });
+
+  publish-main-branch:
+    name: Publish main branch
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/publish-staging-site.yml
+    with:
+      destination_dir: main
+    secrets:
+      PUBLISH_STAGING_PAGES_TOKEN: ${{ secrets.PUBLISH_STAGING_PAGES_TOKEN }}

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -39,6 +39,8 @@ jobs:
         run: yarn build
         env:
           STAGING: true
+          STAGING_PATH_PREFIX: ${{ inputs.destination_dir }}
+          PREFIX_PATHS: true
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
         uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
         with:

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -1,0 +1,48 @@
+name: Publish staging site to GitHub Pages
+
+on:
+  workflow_call:
+    inputs:
+      destination_dir:
+        required: true
+        type: string
+      ref:
+        required: false
+        type: string
+    secrets:
+      PUBLISH_STAGING_PAGES_TOKEN:
+        required: true
+
+jobs:
+  publish-site-to-gh-pages:
+    name: Publish staging site to GitHub Pages
+    runs-on: ubuntu-latest
+    environment: github-pages
+    permissions:
+      contents: write
+    steps:
+      - name: Ensure `destination_dir` is not empty
+        if: ${{ inputs.destination_dir == '' }}
+        run: exit 1
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - name: Install npm dependencies
+        run: yarn --immutable
+      - name: Run build script
+        run: yarn build
+        env:
+          STAGING: true
+      - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
+        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
+        with:
+          personal_token: ${{ secrets.PUBLISH_STAGING_PAGES_TOKEN }}
+          external_repository: MetaMask/snaps-directory-staging
+          publish_dir: ./public
+          destination_dir: ${{ inputs.destination_dir }}

--- a/.github/workflows/publish-staging.yml
+++ b/.github/workflows/publish-staging.yml
@@ -39,7 +39,7 @@ jobs:
         run: yarn build
         env:
           STAGING: true
-          STAGING_PATH_PREFIX: ${{ inputs.destination_dir }}
+          STAGING_PATH_PREFIX: snaps-directory-staging/${{ inputs.destination_dir }}
           PREFIX_PATHS: true
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
         uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935

--- a/README.md
+++ b/README.md
@@ -12,4 +12,7 @@
 
 ## Contributing
 
+The staging version of the directory can be found at
+[metamask.github.io/snaps-directory-staging](https://metamask.github.io/snaps-directory-staging/main).
+
 Please follow our [contributing guidelines](https://github.com/MetaMask/snaps/blob/main/docs/contributing.md).

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,6 +1,11 @@
 /* eslint-disable no-restricted-globals */
 import type { GatsbyConfig } from 'gatsby';
 
+const IS_STAGING = process.env.STAGING === 'true';
+const STAGING_PATH_PREFIX = IS_STAGING
+  ? `/${process.env.STAGING_PATH_PREFIX?.replace(/^\//u, '')}`
+  : '';
+
 const config: GatsbyConfig = {
   siteMetadata: {
     title: 'MetaMask Snaps Directory',
@@ -11,6 +16,7 @@ const config: GatsbyConfig = {
   },
   graphqlTypegen: true,
   jsxRuntime: 'automatic',
+  pathPrefix: STAGING_PATH_PREFIX,
   plugins: [
     'gatsby-plugin-sharp',
     'gatsby-transformer-sharp',

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -3,7 +3,7 @@ import type { GatsbyConfig } from 'gatsby';
 
 const IS_STAGING = process.env.STAGING === 'true';
 const STAGING_PATH_PREFIX = IS_STAGING
-  ? `/${process.env.STAGING_PATH_PREFIX?.replace(/^\//u, '')}`
+  ? `/${process.env.STAGING_PATH_PREFIX}`
   : '';
 
 const config: GatsbyConfig = {

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -41,6 +41,8 @@ type SnapNode = NodeInput & {
   icon?: string | undefined;
 };
 
+// eslint-disable-next-line no-restricted-globals
+const IS_STAGING = process.env.STAGING === 'true';
 const REGISTRY_URL = 'https://acl.execution.consensys.io/latest/registry.json';
 
 /**
@@ -150,8 +152,8 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
   const { registry, customFetch } = await getRegistry();
 
   const verifiedSnaps = Object.values(registry.verifiedSnaps)
-    .filter((snap) => Boolean(snap.metadata.category))
-    .filter((snap) => snap.metadata.hidden !== true);
+    .filter((snap) => IS_STAGING || Boolean(snap.metadata.category))
+    .filter((snap) => IS_STAGING || snap.metadata.hidden !== true);
 
   for (const snap of verifiedSnaps) {
     const latestVersion = getLatestSnapVersion(snap);

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -273,33 +273,37 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data }) => {
         />
       </Box>
 
-      <Divider my="12" />
-      <Flex
-        width="100%"
-        marginBottom="4"
-        flexDirection="row"
-        justifyContent="space-between"
-        alignItems="center"
-      >
-        <Heading as="h2" fontSize="2xl">
-          <Trans>Related Snaps</Trans>
-        </Heading>
-        <Link
-          as={GatsbyLink}
-          to={SNAP_CATEGORY_LINKS[category as RegistrySnapCategory].link}
-          variant="landing"
-        >
-          {i18n._(
-            SNAP_CATEGORY_LINKS[category as RegistrySnapCategory].linkText,
-          )}
-        </Link>
-      </Flex>
-      <FilteredSnaps
-        limit={3}
-        category={category as RegistrySnapCategory}
-        order={Order.Random}
-        excluded={[snapId]}
-      />
+      {category && (
+        <>
+          <Divider my="12" />
+          <Flex
+            width="100%"
+            marginBottom="4"
+            flexDirection="row"
+            justifyContent="space-between"
+            alignItems="center"
+          >
+            <Heading as="h2" fontSize="2xl">
+              <Trans>Related Snaps</Trans>
+            </Heading>
+            <Link
+              as={GatsbyLink}
+              to={SNAP_CATEGORY_LINKS[category as RegistrySnapCategory].link}
+              variant="landing"
+            >
+              {i18n._(
+                SNAP_CATEGORY_LINKS[category as RegistrySnapCategory].linkText,
+              )}
+            </Link>
+          </Flex>
+          <FilteredSnaps
+            limit={3}
+            category={category as RegistrySnapCategory}
+            order={Order.Random}
+            excluded={[snapId]}
+          />
+        </>
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
This changes the workflows to publish a staging site to a separate repo (MetaMask/snaps-directory-staging). The main branch will be accessible from `https://metamask.github.io/snaps-directory-staging/main`, and every PR will be available from `https://metamask.github.io/snaps-directory-staging/pr/<number>`.