### PR TITLE
Show uncategorized snaps in staging

### DIFF
--- a/.github/workflows/publish-staging-site.yml
+++ b/.github/workflows/publish-staging-site.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run build script
         run: yarn build
         env:
-          STAGING: true
+          GATSBY_STAGING: true
           STAGING_PATH_PREFIX: snaps-directory-staging/${{ inputs.destination_dir }}
           PREFIX_PATHS: true
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-globals */
 import type { GatsbyConfig } from 'gatsby';
 
-const IS_STAGING = process.env.STAGING === 'true';
+const IS_STAGING = process.env.GATSBY_STAGING === 'true';
 const STAGING_PATH_PREFIX = IS_STAGING
   ? `/${process.env.STAGING_PATH_PREFIX}`
   : '';

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -46,7 +46,7 @@ type SnapNode = NodeInput & {
 };
 
 // eslint-disable-next-line no-restricted-globals
-const IS_STAGING = process.env.STAGING === 'true';
+const IS_STAGING = process.env.GATSBY_STAGING === 'true';
 const REGISTRY_URL = 'https://acl.execution.metamask.io/latest/registry.json';
 
 /**

--- a/src/features/filter/store.test.ts
+++ b/src/features/filter/store.test.ts
@@ -378,6 +378,56 @@ describe('filterSlice', () => {
       ]);
     });
 
+    it('returns uncategorized snaps in a staging environment', () => {
+      // eslint-disable-next-line n/no-process-env
+      process.env.GATSBY_STAGING = 'true';
+
+      const { snap: fooSnap } = getMockSnap({ snapId: 'foo-snap' });
+      const { snap: barSnap } = getMockSnap({ snapId: 'bar-snap' });
+      const { snap: bazSnap } = getMockSnap({
+        snapId: 'baz-snap',
+        category: undefined,
+      });
+
+      const state = getMockState({
+        filter: {
+          searchQuery: '',
+          searchResults: [],
+          installed: false,
+          categories: [
+            RegistrySnapCategory.Interoperability,
+            RegistrySnapCategory.Notifications,
+            RegistrySnapCategory.TransactionInsights,
+          ],
+          order: Order.Popularity,
+        },
+        snaps: {
+          snaps: [fooSnap, barSnap, bazSnap],
+        },
+        snapsApi: {
+          queries: {
+            'getInstalledSnaps(undefined)': getMockQueryResponse({
+              [fooSnap.snapId]: {
+                version: fooSnap.latestVersion,
+              },
+              [barSnap.snapId]: {
+                version: barSnap.latestVersion,
+              },
+              [bazSnap.snapId]: {
+                version: bazSnap.latestVersion,
+              },
+            }),
+          },
+        },
+      });
+
+      expect(getFilteredSnaps(state)).toStrictEqual([
+        fooSnap,
+        barSnap,
+        bazSnap,
+      ]);
+    });
+
     it('returns the Snaps based on the search results', () => {
       const { snap: fooSnap } = getMockSnap({ snapId: 'foo-snap' });
       const { snap: barSnap } = getMockSnap({ snapId: 'bar-snap' });

--- a/src/features/filter/store.ts
+++ b/src/features/filter/store.ts
@@ -158,6 +158,13 @@ export const getFilteredSnaps = createSelector(
       ? searchedSnaps.filter((snap) => Boolean(installedSnaps[snap.snapId]))
       : searchedSnaps;
 
+    const allSelected = getAll(state);
+    // In staging we also show snaps without categories
+    // eslint-disable-next-line no-restricted-globals
+    if (process.env.GATSBY_STAGING === 'true' && allSelected) {
+      return filteredSnaps;
+    }
+
     return filteredSnaps.filter((snap) =>
       categories.includes(snap?.category as RegistrySnapCategory),
     );

--- a/src/utils/test-utils/queries.ts
+++ b/src/utils/test-utils/queries.ts
@@ -76,7 +76,7 @@ export type GetMockSnapArgs = {
   latestVersion?: string;
   website?: string;
   onboard?: boolean;
-  category?: RegistrySnapCategory;
+  category?: RegistrySnapCategory | undefined;
   author?: Fields<Queries.SnapAuthor, 'name' | 'website'>;
   sourceCode?: string;
   audits?: Fields<Queries.SnapAudits, 'auditor' | 'report'>[];


### PR DESCRIPTION
Show uncategorized snaps on the explore page in the staging environment.

Also renames the `STAGING` environment variable to `GATSBY_STAGING`.