### PR TITLE
Fix banners in staging

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -6,12 +6,16 @@ const STAGING_PATH_PREFIX = IS_STAGING
   ? `/${process.env.STAGING_PATH_PREFIX}`
   : '';
 
+const SITE_URL = IS_STAGING
+  ? `https://metamask.github.io`
+  : 'https://snaps.metamask.io';
+
 const config: GatsbyConfig = {
   siteMetadata: {
     title: 'MetaMask Snaps Directory',
     description:
       'Explore community-built Snaps to customize your web3 experience via our official directory.',
-    siteUrl: 'https://snaps.metamask.io',
+    siteUrl: SITE_URL,
     author: 'MetaMask',
   },
   graphqlTypegen: true,

--- a/src/__mocks__/gatsby.tsx
+++ b/src/__mocks__/gatsby.tsx
@@ -6,6 +6,8 @@ export const navigate = jest.fn();
 
 export const useStaticQuery = jest.fn();
 
+export const withPrefix = jest.fn().mockImplementation((path) => path);
+
 type LinkProps = {
   to: string;
   children: ReactNode;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,6 +1,6 @@
 import { Container, Heading, Button } from '@chakra-ui/react';
 import { Trans } from '@lingui/macro';
-import { graphql, Link } from 'gatsby';
+import { graphql, Link, withPrefix } from 'gatsby';
 import type { FunctionComponent } from 'react';
 
 import banner from '../assets/images/seo/home.png';
@@ -47,7 +47,7 @@ type HeadProps = {
 
 export const Head: FunctionComponent<HeadProps> = ({ data }) => {
   const title = `Page not found - ${data.site.siteMetadata.title}`;
-  const image = `${data.site.siteMetadata.siteUrl}${banner}`;
+  const image = `${data.site.siteMetadata.siteUrl}${withPrefix(banner)}`;
 
   return (
     <>

--- a/src/pages/explore.tsx
+++ b/src/pages/explore.tsx
@@ -1,6 +1,6 @@
 import { Container, Flex, Divider, Heading, Link } from '@chakra-ui/react';
 import { Trans } from '@lingui/macro';
-import { graphql } from 'gatsby';
+import { graphql, withPrefix } from 'gatsby';
 import type { FunctionComponent } from 'react';
 import { useDispatch } from 'react-redux';
 
@@ -76,7 +76,7 @@ type HeadProps = {
 };
 
 export const Head: FunctionComponent<HeadProps> = ({ data }) => {
-  const image = `${data.site.siteMetadata.siteUrl}${banner}`;
+  const image = `${data.site.siteMetadata.siteUrl}${withPrefix(banner)}`;
 
   return (
     <>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@chakra-ui/react';
 import { defineMessage, Trans } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
-import { graphql, Link as GatsbyLink } from 'gatsby';
+import { graphql, Link as GatsbyLink, withPrefix } from 'gatsby';
 import { useEffect, type FunctionComponent } from 'react';
 
 import banner from '../assets/images/seo/home.png';
@@ -142,7 +142,7 @@ type HeadProps = {
 };
 
 export const Head: FunctionComponent<HeadProps> = ({ data }) => {
-  const image = `${data.site.siteMetadata.siteUrl}${banner}`;
+  const image = `${data.site.siteMetadata.siteUrl}${withPrefix(banner)}`;
 
   return (
     <>


### PR DESCRIPTION
This fixes the SEO banners in the staging environment. The site URL as previously always set to `snaps.metamask.io`, and some banner URLs weren't being prefixed properly.