### PR TITLE
Fix grid alignment

### DIFF
--- a/src/features/snaps/FilteredSnaps.tsx
+++ b/src/features/snaps/FilteredSnaps.tsx
@@ -34,7 +34,7 @@ export const FilteredSnaps: FunctionComponent<FilteredSnapsProps> = ({
   }
 
   return (
-    <SimpleGrid columns={[1, null, 2, 3]} spacing={4}>
+    <SimpleGrid columns={[1, null, 2, 3]} spacing={4} marginX="-0.5rem">
       {snaps.map((snap, index) => (
         <SnapCard key={`${snap.id}-${index}`} {...snap} />
       ))}


### PR DESCRIPTION
This fixes the alignment of the Snap cards in the grid, so they align with the key lines.