### PR TITLE
Fix fallback background for `SnapCardImage`

### DIFF
--- a/src/features/snaps/components/SnapCardImage.tsx
+++ b/src/features/snaps/components/SnapCardImage.tsx
@@ -27,6 +27,7 @@ export const SnapCardImage: FunctionComponent<SnapCardImageProps> = ({
       name={name.slice(0, 1).toUpperCase()}
       fontSize="md"
       color="text.alternative"
+      background="background.alternative"
       size="md"
       width="6rem"
       height="6rem"


### PR DESCRIPTION
Makes `SnapCardImage` use the same fallback color as `SnapAvatar`, removing weird red colored background when loading.

Fixes #267 