### PR TITLE
Fix background color on `SnapCardImage`

### DIFF
--- a/src/features/snaps/components/SnapCardImage.tsx
+++ b/src/features/snaps/components/SnapCardImage.tsx
@@ -21,13 +21,19 @@ export const SnapCardImage: FunctionComponent<SnapCardImageProps> = ({
     alignItems="center"
     justifyContent="center"
     data-testid="snap-card-image"
+    sx={{
+      // This is a bit hacky, but sets the background color for the avatar component
+      // only when the fallback icon is shown.
+      '.chakra-avatar:has(div)': {
+        backgroundColor: 'background.alternative',
+      },
+    }}
   >
     <Avatar
       src={icon}
       name={name.slice(0, 1).toUpperCase()}
       fontSize="md"
       color="text.alternative"
-      background="background.alternative"
       size="md"
       width="6rem"
       height="6rem"


### PR DESCRIPTION
Previously I merged #286 to fix an issue with the background color on the fallback image for `SnapCardImage`.

This PR had an unexpected side-effect of also using this background color for avatars that use transparency.

![image](https://github.com/MetaMask/snaps-directory/assets/1561200/d02c0de9-8e39-47b0-b865-60cbf58e4ad2)

This PR fixes this problem by conditionally applying the background color instead.
