### PR TITLE
Move account management category to the top on index page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,6 +20,15 @@ const GROUPS = [
     images: true,
   },
   {
+    header: SNAP_CATEGORY_LINKS[RegistrySnapCategory.AccountManagement].header,
+    category: RegistrySnapCategory.AccountManagement,
+    limit: 3,
+    link: SNAP_CATEGORY_LINKS[RegistrySnapCategory.AccountManagement].link,
+    linkText:
+      SNAP_CATEGORY_LINKS[RegistrySnapCategory.AccountManagement].linkText,
+    order: Order.DeterministicRandom,
+  },
+  {
     header: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Interoperability].header,
     category: RegistrySnapCategory.Interoperability,
     limit: 6,
@@ -44,15 +53,6 @@ const GROUPS = [
     limit: 3,
     link: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Notifications].link,
     linkText: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Notifications].linkText,
-    order: Order.DeterministicRandom,
-  },
-  {
-    header: SNAP_CATEGORY_LINKS[RegistrySnapCategory.AccountManagement].header,
-    category: RegistrySnapCategory.AccountManagement,
-    limit: 3,
-    link: SNAP_CATEGORY_LINKS[RegistrySnapCategory.AccountManagement].link,
-    linkText:
-      SNAP_CATEGORY_LINKS[RegistrySnapCategory.AccountManagement].linkText,
     order: Order.DeterministicRandom,
   },
   {


### PR DESCRIPTION
This moves the account management category to the top (just below the most popular) on the index page.