### PR TITLE
Set up Crowdin translations

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,30 @@
+name: Crowdin
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 */12 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  synchronize-crowdin:
+    name: Synchronize with Crowdin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Crowdin
+        uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d
+        with:
+          upload_translations: true
+          download_translations: true
+          github_user_name: metamaskbot
+          github_user_email: metamaskbot@users.noreply.github.com
+        env:
+          GITHUB_ACTOR: metamaskbot
+          GITHUB_TOKEN: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,12 @@
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+base_path: .
+
+preserve_hierarchy: true
+
+files:
+  - source: /src/locales/en-US/messages.po
+    translation: /src/locales/%locale%/%original_file_name%
+    type: gettext
+    ignore:
+      - /src/locales/*/messages.d.ts

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -4,6 +4,7 @@ import { formatter } from '@lingui/format-po';
 const config: LinguiConfig = {
   compileNamespace: 'es',
   locales: ['de-DE', 'en-US', 'ja-JP', 'pt-BR', 'ru-RU', 'tr-TR', 'zh-CN'],
+  sourceLocale: 'en-US',
   format: formatter({ lineNumbers: false }),
   catalogs: [
     {


### PR DESCRIPTION
This sets up the Crowdin GitHub action for synchronising the translations with Crowdin. The configuration is mostly the same as the one used in the extension.