### PR TITLE
Fix translation in permission

### DIFF
--- a/src/features/snap/permissions.test.tsx
+++ b/src/features/snap/permissions.test.tsx
@@ -627,8 +627,8 @@ describe('SNAP_PERMISSIONS', () => {
         Array [
           Object {
             "description": Object {
-              "id": "rh23nf",
-              "message": "Allow {name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets.",
+              "id": "qogTk8",
+              "message": "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets.",
               "values": Object {
                 "name": "Snap",
               },
@@ -648,8 +648,8 @@ describe('SNAP_PERMISSIONS', () => {
           },
           Object {
             "description": Object {
-              "id": "rh23nf",
-              "message": "Allow {name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets.",
+              "id": "qogTk8",
+              "message": "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets.",
               "values": Object {
                 "name": "Snap",
               },
@@ -670,8 +670,8 @@ describe('SNAP_PERMISSIONS', () => {
           },
           Object {
             "description": Object {
-              "id": "rh23nf",
-              "message": "Allow {name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets.",
+              "id": "qogTk8",
+              "message": "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets.",
               "values": Object {
                 "name": "Snap",
               },
@@ -880,8 +880,8 @@ describe('getPermissions', () => {
       Array [
         Object {
           "description": Object {
-            "id": "rh23nf",
-            "message": "Allow {name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets.",
+            "id": "qogTk8",
+            "message": "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets.",
             "values": Object {
               "name": "Snap",
             },

--- a/src/features/snap/permissions.tsx
+++ b/src/features/snap/permissions.tsx
@@ -281,7 +281,7 @@ export const SNAP_PERMISSIONS: PermissionsMap = {
 
       return {
         label,
-        description: defineMessage`Allow ${name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets.`,
+        description: defineMessage`Allow ${name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets.`,
         icon: SecuritySearchIcon,
         weight: 2,
       };

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -142,8 +142,8 @@ msgid "Allow {name} to use lifecycle hooks to run code at specific times during 
 msgstr "Erlauben Sie {name}, Lebenszyklus-Hooks zu verwenden, um Code zu bestimmten Zeiten während seines Lebenszyklus auszuführen."
 
 #: src/features/snap/permissions.tsx
-msgid "Allow {name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets."
-msgstr "Erlauben Sie {name}, Ihre öffentlichen Schlüssel (und Adressen) für $1 einzusehen. Dies gewährt keine Kontrolle über Konten oder Assets."
+msgid "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets."
+msgstr ""
 
 #: src/features/snap/permissions.tsx
 msgid "Allow {origin} to communicate with {name}"

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -137,8 +137,8 @@ msgid "Allow {name} to use lifecycle hooks to run code at specific times during 
 msgstr ""
 
 #: src/features/snap/permissions.tsx
-msgid "Allow {name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets."
-msgstr ""
+msgid "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets."
+msgstr "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets."
 
 #: src/features/snap/permissions.tsx
 msgid "Allow {origin} to communicate with {name}"

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -142,7 +142,7 @@ msgid "Allow {name} to use lifecycle hooks to run code at specific times during 
 msgstr ""
 
 #: src/features/snap/permissions.tsx
-msgid "Allow {name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets."
+msgid "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets."
 msgstr ""
 
 #: src/features/snap/permissions.tsx

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -142,8 +142,8 @@ msgid "Allow {name} to use lifecycle hooks to run code at specific times during 
 msgstr "Permitir que {name} use ganchos de ciclo de vida para executar código em horários específicos durante seu ciclo de vida."
 
 #: src/features/snap/permissions.tsx
-msgid "Allow {name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets."
-msgstr "Permitir que {name} veja suas chaves públicas (e endereços) de $1. Isso não concede nenhum controle de contas ou ativos."
+msgid "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets."
+msgstr ""
 
 #: src/features/snap/permissions.tsx
 msgid "Allow {origin} to communicate with {name}"

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -142,8 +142,8 @@ msgid "Allow {name} to use lifecycle hooks to run code at specific times during 
 msgstr "Разрешите {name} использовать обработчики жизненного цикла для запуска кода в определенное время в течение его жизненного цикла."
 
 #: src/features/snap/permissions.tsx
-msgid "Allow {name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets."
-msgstr "Разрешите {name} просматривать ваши открытые ключи (и адреса) для $1. Это не дает никакого контроля над счетами или активами."
+msgid "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets."
+msgstr ""
 
 #: src/features/snap/permissions.tsx
 msgid "Allow {origin} to communicate with {name}"

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -142,8 +142,8 @@ msgid "Allow {name} to use lifecycle hooks to run code at specific times during 
 msgstr "Bu yaşam döngüsü sırasında belirli zamanlarda kod çalıştırmak için {name} adlı snap'in yaşam döngüsü kancalarını kullanmasına izin verin."
 
 #: src/features/snap/permissions.tsx
-msgid "Allow {name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets."
-msgstr "{name} adlı snap'in $1 için genel anahtarları (ve adresleri) görüntülemesine izin verin. Bu eylem, herhangi bir şekilde hesapların ya da varlıkların kontrolünü vermez."
+msgid "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets."
+msgstr ""
 
 #: src/features/snap/permissions.tsx
 msgid "Allow {origin} to communicate with {name}"

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -142,8 +142,8 @@ msgid "Allow {name} to use lifecycle hooks to run code at specific times during 
 msgstr "允许 {name} 使用生命周期挂钩，在其生命周期的特定时间运行代码。"
 
 #: src/features/snap/permissions.tsx
-msgid "Allow {name} to view your public keys (and addresses) for $1. This does not grant any control of accounts or assets."
-msgstr "允许 {name} 查看您的 $1 公钥（和地址）。这并不会授予对账户或资产的任何控制权。"
+msgid "Allow {name} to view your public keys (and addresses) for the requested network. This does not grant any control of accounts or assets."
+msgstr ""
 
 #: src/features/snap/permissions.tsx
 msgid "Allow {origin} to communicate with {name}"


### PR DESCRIPTION
One of the permission descriptions was using `$1`, which was a leftover from copying from the extension. This replaces it with "the requested network" which is consistent with the other permissions.