### PR TITLE
Add EIP-6963 support

### DIFF
--- a/src/store/api.test.ts
+++ b/src/store/api.test.ts
@@ -91,7 +91,12 @@ describe('request', () => {
   it('returns `null` if the provider is not available', async () => {
     Object.defineProperty(globalThis, 'window', {
       writable: true,
-      value: {},
+      value: {
+        ethereum: undefined,
+        addEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
+      },
     });
 
     expect(

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,4 +1,8 @@
-import type { MetaMaskInpageProvider } from '@metamask/providers';
+import type {
+  EIP6963AnnounceProviderEvent,
+  EIP6963RequestProviderEvent,
+  MetaMaskInpageProvider,
+} from '@metamask/providers';
 
 import type { SnapEventType } from '../analytics';
 
@@ -14,5 +18,11 @@ declare global {
     analytics: {
       track: (event: SnapEventType, data: unknown) => void;
     };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  interface WindowEventMap {
+    'eip6963:requestProvider': EIP6963RequestProviderEvent;
+    'eip6963:announceProvider': EIP6963AnnounceProviderEvent;
   }
 }

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -10,6 +10,20 @@ import {
 } from './snaps';
 import { getRequestMethodMock } from './test-utils';
 
+const MOCK_EIP6963_PROVIDER = { request: jest.fn() };
+
+// eslint-disable-next-line no-restricted-globals
+const MOCK_EIP6963_ANNOUNCEMENT = new CustomEvent('eip6963:announceProvider', {
+  detail: {
+    info: {
+      name: 'MetaMask',
+      rdns: 'io.metamask',
+      uuid: '359b317d-0e02-4cea-ade8-7f671fdd5c7e',
+    },
+    provider: MOCK_EIP6963_PROVIDER,
+  },
+});
+
 describe('hasSnapsSupport', () => {
   it('returns `true` if the provider supports Snaps', async () => {
     const provider = getRequestMethodMock({
@@ -76,6 +90,9 @@ describe('getMetaMaskProvider', () => {
       writable: true,
       value: {
         ethereum: undefined,
+        addEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
       },
     });
 
@@ -143,6 +160,24 @@ describe('getMetaMaskProvider', () => {
 
     expect(await getMetaMaskProvider()).toBe(provider);
   });
+
+  it('returns the provider if it is available via EIP6963', async () => {
+    Object.defineProperty(globalThis, 'window', {
+      writable: true,
+      value: {
+        ethereum: undefined,
+        addEventListener: jest.fn().mockImplementation((type, listener) => {
+          if (type === 'eip6963:announceProvider') {
+            listener(MOCK_EIP6963_ANNOUNCEMENT);
+          }
+        }),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
+      },
+    });
+
+    expect(await getMetaMaskProvider()).toStrictEqual(MOCK_EIP6963_PROVIDER);
+  });
 });
 
 describe('getSnapsProvider', () => {
@@ -162,6 +197,9 @@ describe('getSnapsProvider', () => {
       writable: true,
       value: {
         ethereum: undefined,
+        addEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
       },
     });
 
@@ -228,6 +266,24 @@ describe('getSnapsProvider', () => {
     });
 
     expect(await getSnapsProvider()).toBe(provider);
+  });
+
+  it('returns the provider if it is available via EIP6963', async () => {
+    Object.defineProperty(globalThis, 'window', {
+      writable: true,
+      value: {
+        ethereum: undefined,
+        addEventListener: jest.fn().mockImplementation((type, listener) => {
+          if (type === 'eip6963:announceProvider') {
+            listener(MOCK_EIP6963_ANNOUNCEMENT);
+          }
+        }),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
+      },
+    });
+
+    expect(await getSnapsProvider()).toStrictEqual(MOCK_EIP6963_PROVIDER);
   });
 });
 

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -24,6 +24,21 @@ const MOCK_EIP6963_ANNOUNCEMENT = new CustomEvent('eip6963:announceProvider', {
   },
 });
 
+// eslint-disable-next-line no-restricted-globals
+const MOCK_EIP6963_ANNOUNCEMENT_NON_METAMASK = new CustomEvent(
+  'eip6963:announceProvider',
+  {
+    detail: {
+      info: {
+        name: 'Some other wallet',
+        rdns: 'foo.bar',
+        uuid: '7da4d4cb-5265-4138-b5d9-c3fc97798ee1',
+      },
+      provider: null,
+    },
+  },
+);
+
 describe('hasSnapsSupport', () => {
   it('returns `true` if the provider supports Snaps', async () => {
     const provider = getRequestMethodMock({
@@ -168,6 +183,7 @@ describe('getMetaMaskProvider', () => {
         ethereum: undefined,
         addEventListener: jest.fn().mockImplementation((type, listener) => {
           if (type === 'eip6963:announceProvider') {
+            listener(MOCK_EIP6963_ANNOUNCEMENT_NON_METAMASK);
             listener(MOCK_EIP6963_ANNOUNCEMENT);
           }
         }),
@@ -275,6 +291,7 @@ describe('getSnapsProvider', () => {
         ethereum: undefined,
         addEventListener: jest.fn().mockImplementation((type, listener) => {
           if (type === 'eip6963:announceProvider') {
+            listener(MOCK_EIP6963_ANNOUNCEMENT_NON_METAMASK);
             listener(MOCK_EIP6963_ANNOUNCEMENT);
           }
         }),

--- a/src/utils/snaps.ts
+++ b/src/utils/snaps.ts
@@ -1,4 +1,7 @@
-import type { MetaMaskInpageProvider } from '@metamask/providers';
+import type {
+  EIP6963AnnounceProviderEvent,
+  MetaMaskInpageProvider,
+} from '@metamask/providers';
 import type { SnapsRegistryDatabase } from '@metamask/snaps-registry';
 import semver from 'semver/preload';
 
@@ -55,6 +58,55 @@ export async function isMetaMaskProvider(
 }
 
 /**
+ * Get a MetaMask provider using EIP6963. This will return the first provider
+ * reporting as MetaMask. If no provider is found after 500ms, this will
+ * return null instead.
+ *
+ * @returns A MetaMask provider if found, otherwise null.
+ */
+export async function getMetaMaskEIP6963Provider() {
+  return new Promise<MetaMaskInpageProvider | null>((rawResolve) => {
+    // Timeout looking for providers after 500ms
+    const timeout = setTimeout(() => {
+      resolve(null);
+    }, 500);
+
+    /**
+     * Resolve the promise with a MetaMask provider and clean up.
+     *
+     * @param provider - A MetaMask provider if found, otherwise null.
+     */
+    function resolve(provider: MetaMaskInpageProvider | null) {
+      window.removeEventListener(
+        'eip6963:announceProvider',
+        onAnnounceProvider,
+      );
+      clearTimeout(timeout);
+      rawResolve(provider);
+    }
+
+    /**
+     * Listener for the EIP6963 announceProvider event.
+     *
+     * Resolves the promise if a MetaMask provider is found.
+     *
+     * @param event - The EIP6963 announceProvider event.
+     */
+    function onAnnounceProvider(event: EIP6963AnnounceProviderEvent) {
+      const { info, provider } = event.detail;
+
+      if (info.rdns.includes('io.metamask')) {
+        resolve(provider);
+      }
+    }
+
+    window.addEventListener('eip6963:announceProvider', onAnnounceProvider);
+
+    window.dispatchEvent(new Event('eip6963:requestProvider'));
+  });
+}
+
+/**
  * Get a MetaMask provider. This will loop through all the detected providers
  * and return the first one that is MetaMask.
  */
@@ -81,6 +133,12 @@ export async function getMetaMaskProvider() {
         return provider;
       }
     }
+  }
+
+  const eip6963Provider = await getMetaMaskEIP6963Provider();
+
+  if (eip6963Provider) {
+    return eip6963Provider;
   }
 
   return null;
@@ -115,6 +173,12 @@ export async function getSnapsProvider() {
         return provider;
       }
     }
+  }
+
+  const eip6963Provider = await getMetaMaskEIP6963Provider();
+
+  if (eip6963Provider && (await hasSnapsSupport(eip6963Provider))) {
+    return eip6963Provider;
   }
 
   return null;


### PR DESCRIPTION
Adds support for detecting the MetaMask provider via EIP-6963 if the existing logic fails. This in turn makes snaps installable in browsers where multiple wallets are fighting to inject `window.ethereum`.

The site will still prefer `window.ethereum` for now as it is instant and use EIP-6963 as a fallback, this may change in the future.

Closes https://github.com/MetaMask/snaps-directory/issues/280