### PR TITLE
Update banner link and ordering

### DIFF
--- a/src/features/banner/Banner.tsx
+++ b/src/features/banner/Banner.tsx
@@ -17,8 +17,8 @@ export const Banner: FunctionComponent<BannerProps> = ({ snaps }) => (
   <Box height="21.875rem">
     <Carousel>
       <ExploreBanner snaps={snaps} key="explore-banner" />
-      <FaqBanner key="faq-banner" />
       <CreateSnapBanner key="create-snap-banner" />
+      <FaqBanner key="faq-banner" />
     </Carousel>
   </Box>
 );

--- a/src/features/banner/components/create-snap-banner/CreateSnapBanner.tsx
+++ b/src/features/banner/components/create-snap-banner/CreateSnapBanner.tsx
@@ -9,7 +9,7 @@ import { Base } from '../Base';
 
 export const CreateSnapBanner: FunctionComponent = () => (
   <Base
-    to="https://docs.metamask.io/snaps/how-to/develop-a-snap/"
+    to="https://docs.metamask.io/snaps/"
     external={true}
     // Based on `success.muted`, but without opacity.
     background="#E8F2EA"


### PR DESCRIPTION
This moves the FAQ banner to be the last one in the list, and updates the link on the create banner.