### PR TITLE
Tweak popularity calculation

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -227,10 +227,23 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
     const lastUpdated = new Date(time[latestVersion]).getTime();
 
     const downloadsJson = await customFetch(
-      `https://api.npmjs.org/downloads/point/last-year/${slug}`,
+      `https://api.npmjs.org/versions/${slug.replace('/', '%2F')}/last-week`,
     ).then(async (response: any) => response.json());
 
-    const { downloads } = downloadsJson;
+    const { downloads } = downloadsJson as {
+      downloads: Record<string, number>;
+    };
+
+    const allVersions = Object.keys(snap.versions);
+    const totalDownloads = Object.entries(downloads).reduce(
+      (total, [version, count]) => {
+        if (allVersions.includes(version)) {
+          return total + count;
+        }
+        return total;
+      },
+      0,
+    );
 
     const content = {
       ...snap.metadata,
@@ -242,7 +255,7 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
       slug,
       latestVersion,
       icon,
-      downloads,
+      downloads: totalDownloads,
       lastUpdated,
 
       // We need to stringify the permissions because Gatsby doesn't support

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -227,7 +227,7 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
     const lastUpdated = new Date(time[latestVersion]).getTime();
 
     const downloadsJson = await customFetch(
-      `https://api.npmjs.org/versions/${slug.replace('/', '%2F')}/last-week`,
+      `https://api.npmjs.org/versions/${slug.replace(/\//gu, '%2F')}/last-week`,
     ).then(async (response: any) => response.json());
 
     const { downloads } = downloadsJson as {

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -227,7 +227,7 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
     const lastUpdated = new Date(time[latestVersion]).getTime();
 
     const downloadsJson = await customFetch(
-      `https://api.npmjs.org/versions/${slug.replace(/\//gu, '%2F')}/last-week`,
+      `https://api.npmjs.org/versions/${encodeURIComponent(slug)}/last-week`,
     ).then(async (response: any) => response.json());
 
     const { downloads } = downloadsJson as {


### PR DESCRIPTION
Tweak popularity calculation by only counting the last week of downloads and exclusively counting versions of the package that has been put on the allowlist.