### PR TITLE
Improve modal behavior

### DIFF
--- a/.yarn/patches/@chakra-ui-focus-lock-npm-2.1.0-46e41f49ee.patch
+++ b/.yarn/patches/@chakra-ui-focus-lock-npm-2.1.0-46e41f49ee.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/chunk-UU5OHSNF.mjs b/dist/chunk-UU5OHSNF.mjs
+index ab2da7c6549ee5bf14954007159237ed727f4626..e5ae5c92a26c04188c0b15eed85721cd3e61de77 100644
+--- a/dist/chunk-UU5OHSNF.mjs
++++ b/dist/chunk-UU5OHSNF.mjs
+@@ -46,7 +46,8 @@ var FocusLock = (props) => {
+       disabled: isDisabled,
+       onActivation,
+       onDeactivation,
+-      returnFocus,
++      // We prefer not scrolling when returning focus, but Chakra doesn't currently support that.
++      returnFocus: returnFocus ? { preventScroll: true } : false,
+       children
+     }
+   );
+diff --git a/dist/focus-lock.js b/dist/focus-lock.js
+index 9bbab83ca824e2da993bb5af1cf3cbaa3613469c..4484343331e4cb216a7064b1571bb12495089e8f 100644
+--- a/dist/focus-lock.js
++++ b/dist/focus-lock.js
+@@ -80,7 +80,8 @@ var FocusLock = (props) => {
+       disabled: isDisabled,
+       onActivation,
+       onDeactivation,
+-      returnFocus,
++      // We prefer not scrolling when returning focus, but Chakra doesn't currently support that.
++      returnFocus: returnFocus ? { preventScroll: true } : false,
+       children
+     }
+   );

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     ]
   },
   "resolutions": {
+    "@chakra-ui/focus-lock@2.1.0": "patch:@chakra-ui/focus-lock@npm%3A2.1.0#./.yarn/patches/@chakra-ui-focus-lock-npm-2.1.0-46e41f49ee.patch",
     "@noble/hashes@1.3.1": "patch:@noble/hashes@npm%3A1.3.2#./.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch",
     "@noble/hashes@^1.0.0": "patch:@noble/hashes@npm%3A1.3.2#./.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch",
     "@noble/hashes@^1.3.1": "patch:@noble/hashes@npm%3A1.3.2#./.yarn/patches/@noble-hashes-npm-1.3.2-1e619f9da0.patch",

--- a/src/components/InstallUnsupportedDesktop.tsx
+++ b/src/components/InstallUnsupportedDesktop.tsx
@@ -28,7 +28,13 @@ export const InstallUnsupportedDesktop: FunctionComponent<
   const isSupported = useSupportedVersion();
 
   return (
-    <Modal variant="minimal" size="xs" isOpen={isOpen} onClose={onClose}>
+    <Modal
+      variant="minimal"
+      size="xs"
+      isOpen={isOpen}
+      onClose={onClose}
+      preserveScrollBarGap
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalBody>

--- a/src/components/PostInstallModal.tsx
+++ b/src/components/PostInstallModal.tsx
@@ -50,7 +50,13 @@ export const PostInstallModal: FunctionComponent<PostInstallModalProps> = ({
 }) => {
   return (
     <>
-      <Modal variant="minimal" size="xs" isOpen={isOpen} onClose={onClose}>
+      <Modal
+        variant="minimal"
+        size="xs"
+        isOpen={isOpen}
+        onClose={onClose}
+        preserveScrollBarGap
+      >
         <ModalOverlay />
         <ModalContent>
           <ModalBody>

--- a/src/features/snap/components/MetadataModal.tsx
+++ b/src/features/snap/components/MetadataModal.tsx
@@ -55,7 +55,12 @@ export const MetadataModal: FunctionComponent<MetadataModalProps> = ({
   } = snap;
 
   return (
-    <Modal variant="minimal" isOpen={isOpen} onClose={onClose}>
+    <Modal
+      variant="minimal"
+      isOpen={isOpen}
+      onClose={onClose}
+      preserveScrollBarGap
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />

--- a/src/features/snap/components/Screenshots.tsx
+++ b/src/features/snap/components/Screenshots.tsx
@@ -71,6 +71,7 @@ export const Screenshots: FunctionComponent<ScreenshotsProps> = ({
         onClose={onClose}
         size="4xl"
         isCentered
+        preserveScrollBarGap
       >
         <ModalOverlay />
         <ModalContent overflow="hidden">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,6 +1884,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chakra-ui/focus-lock@patch:@chakra-ui/focus-lock@npm%3A2.1.0#./.yarn/patches/@chakra-ui-focus-lock-npm-2.1.0-46e41f49ee.patch::locator=%40metamask%2Fsnaps-directory%40workspace%3A.":
+  version: 2.1.0
+  resolution: "@chakra-ui/focus-lock@patch:@chakra-ui/focus-lock@npm%3A2.1.0#./.yarn/patches/@chakra-ui-focus-lock-npm-2.1.0-46e41f49ee.patch::version=2.1.0&hash=12e677&locator=%40metamask%2Fsnaps-directory%40workspace%3A."
+  dependencies:
+    "@chakra-ui/dom-utils": 2.1.0
+    react-focus-lock: ^2.9.4
+  peerDependencies:
+    react: ">=18"
+  checksum: 9034905acd1dc54936d2efbf7ed461ebec489554943b9f30d3700d8b11be52cfa21d4d92d42c9834dc7a00ed25b17530794de87470bc9f1404d33f8990f567d3
+  languageName: node
+  linkType: hard
+
 "@chakra-ui/form-control@npm:2.1.0":
   version: 2.1.0
   resolution: "@chakra-ui/form-control@npm:2.1.0"


### PR DESCRIPTION
This PR does two things to improve the modal behavior: 
- Firstly it enables `preserveScrollBarGap`, this is supposed to be enabled by default in Chakra according to the documentation, but isn't. This prevents the page jumping around when modals are opened.
- Secondly it patches `@chakra-ui/focus-lock` to prevent scrolling when returning focus (e.g. when closing a modal). Chakra uses `react-focus-lock` under the hood which supports not scrolling, but this functionality is not currently supported in Chakra.