### PR TITLE
Use data endpoint for installation numbers

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -60,7 +60,7 @@ const REGISTRY_URL = 'https://acl.execution.metamask.io/latest/registry.json';
 const SIGNATURE_URL = 'https://acl.execution.metamask.io/latest/signature.json';
 const PUBLIC_KEY =
   '0x025b65308f0f0fb8bc7f7ff87bfc296e0330eee5d3c1d1ee4a048b2fd6a86fa0a6';
-const STATS_URL = 'https://data.snaps.metamask.io/';
+const STATS_URL = 'https://dev.data.snaps.metamask.io/';
 
 const HEADERS = {
   'User-Agent':
@@ -188,13 +188,17 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
   const { registry, customFetch } = await getRegistry();
 
   const rawStats = await customFetch(STATS_URL, { headers: HEADERS }).then(
-    async (response: any) => response.json(),
+    async (response: any) => response.text(),
   );
 
-  const stats = rawStats.reduce((acc, snap) => {
-    acc[snap.snap_id] = snap.installs;
-    return acc;
-  }, {});
+  const stats = rawStats
+    .split('\n')
+    .slice(0, -1)
+    .reduce((acc, json) => {
+      const snap = JSON.parse(json);
+      acc[snap.snap_id] = parseInt(snap.installs, 10);
+      return acc;
+    }, {});
 
   const verifiedSnaps = Object.values(registry.verifiedSnaps)
     .filter((snap) => IS_STAGING || Boolean(snap.metadata.category))

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -244,7 +244,7 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
 
     const lastUpdated = new Date(time[latestVersion]).getTime();
 
-    const downloads = stats[snap.id] ?? 0;
+    const installs = stats[snap.id] ?? 0;
 
     const nodeId = createNodeId(`snap__${snap.id}`);
 
@@ -281,7 +281,7 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
       slug,
       latestVersion,
       icon,
-      downloads,
+      installs,
       lastUpdated,
 
       screenshotFiles: screenshotNodes.map(

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -192,8 +192,7 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
   );
 
   const stats = rawStats.reduce((acc, snap) => {
-    const id = snap.snap_id.replaceAll('/', '/');
-    acc[id] = snap.installs;
+    acc[snap.snap_id] = snap.installs;
     return acc;
   }, {});
 

--- a/src/components/SnapsProvider.tsx
+++ b/src/components/SnapsProvider.tsx
@@ -34,7 +34,7 @@ export const SnapsProvider: FunctionComponent<SnapsProviderProps> = ({
           latestVersion
           category
           gatsbyPath(filePath: "/snap/{Snap.location}/{Snap.slug}")
-          downloads
+          installs
           lastUpdated
         }
       }

--- a/src/features/filter/sort.ts
+++ b/src/features/filter/sort.ts
@@ -18,7 +18,7 @@ export const SORT_FUNCTIONS = {
     snaps.concat().sort((a, b) => a.name.localeCompare(b.name)),
 
   [Order.Popularity]: (snaps: Snap[]) =>
-    snaps.concat().sort((a, b) => b.downloads - a.downloads),
+    snaps.concat().sort((a, b) => b.installs - a.installs),
 
   [Order.Latest]: (snaps: Snap[]) =>
     snaps.concat().sort((a, b) => b.lastUpdated - a.lastUpdated),

--- a/src/features/filter/store.test.ts
+++ b/src/features/filter/store.test.ts
@@ -635,17 +635,17 @@ describe('filterSlice', () => {
       const { snap: fooSnap } = getMockSnap({
         snapId: 'foo-snap',
         name: 'Foo',
-        downloads: 100,
+        installs: 100,
       });
       const { snap: barSnap } = getMockSnap({
         snapId: 'bar-snap',
         name: 'Bar',
-        downloads: 300,
+        installs: 300,
       });
       const { snap: bazSnap } = getMockSnap({
         snapId: 'baz-snap',
         name: 'Baz',
-        downloads: 5,
+        installs: 5,
       });
 
       const state = getMockState({

--- a/src/features/snaps/store.ts
+++ b/src/features/snaps/store.ts
@@ -19,7 +19,7 @@ export type Snap = Fields<
   | 'category'
   | 'gatsbyPath'
   | 'latestVersion'
-  | 'downloads'
+  | 'installs'
   | 'lastUpdated'
 >;
 

--- a/src/utils/test-utils/queries.ts
+++ b/src/utils/test-utils/queries.ts
@@ -232,7 +232,7 @@ export type MockSnap = Fields<
   | 'banner'
   | 'support'
   | 'gatsbyPath'
-  | 'downloads'
+  | 'installs'
   | 'lastUpdated'
   | 'permissions'
   | 'privateCode'
@@ -266,7 +266,7 @@ export type GetMockSnapArgs = {
     >
   >;
   gatsbyPath?: string;
-  downloads?: number;
+  installs?: number;
   lastUpdated?: number;
   permissions?: InitialPermissions;
   privateCode?: boolean;
@@ -296,7 +296,7 @@ export type GetMockSnapArgs = {
  * @param args.banner - The banner.
  * @param args.support - The support page URL.
  * @param args.gatsbyPath - The Gatsby path.
- * @param args.downloads - The number of downloads.
+ * @param args.installs - The number of installs.
  * @param args.lastUpdated - A unix timestamp of the last update to the snap.
  * @param args.permissions - The Snap's initial permissions.
  * @param args.privateCode - Whether the Snap's source code is (partially)
@@ -342,7 +342,7 @@ export function getMockSnap({
     keyRecovery: 'https://example.com/key-recovery',
   },
   gatsbyPath = `/snap/${snapId}`,
-  downloads = 0,
+  installs = 0,
   lastUpdated = 1701260892,
   permissions = {
     'endowment:rpc': {
@@ -376,7 +376,7 @@ export function getMockSnap({
         keyof Queries.SnapSupport
       >,
       gatsbyPath,
-      downloads,
+      installs,
       lastUpdated,
       permissions,
       privateCode,


### PR DESCRIPTION
Use data endpoint for installation numbers, which should give more accurate installation numbers compared to relying on NPM.