### PR TITLE
Change category names

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -325,7 +325,10 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
 
       return result;
     },
-    new Set<string>(Object.keys(LEGACY_CATEGORIES)),
+    new Set<string>([
+      ...Object.keys(LEGACY_CATEGORIES),
+      ...Object.values(LEGACY_CATEGORIES),
+    ]),
   );
 
   for (const category of categories) {

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -61,10 +61,10 @@ const SIGNATURE_URL = 'https://acl.execution.metamask.io/latest/signature.json';
 const PUBLIC_KEY =
   '0x025b65308f0f0fb8bc7f7ff87bfc296e0330eee5d3c1d1ee4a048b2fd6a86fa0a6';
 
-const LEGACY_CATEGORIES = {
+const LEGACY_CATEGORIES: Record<string, string> = {
   'transaction insights': 'security',
   notifications: 'communication',
-} as Record<string, string>;
+};
 
 /**
  * Normalize the description to ensure it ends with a period. This also replaces

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -61,6 +61,11 @@ const SIGNATURE_URL = 'https://acl.execution.metamask.io/latest/signature.json';
 const PUBLIC_KEY =
   '0x025b65308f0f0fb8bc7f7ff87bfc296e0330eee5d3c1d1ee4a048b2fd6a86fa0a6';
 
+const LEGACY_CATEGORIES = {
+  'transaction insights': 'security',
+  notifications: 'communication',
+} as Record<string, string>;
+
 /**
  * Normalize the description to ensure it ends with a period. This also replaces
  * "Metamask" with "MetaMask".
@@ -268,8 +273,13 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
       ),
     );
 
+    const migratedCategory =
+      snap.metadata.category && LEGACY_CATEGORIES[snap.metadata.category];
+    const category = migratedCategory ?? snap.metadata.category;
+
     const content = {
       ...snap.metadata,
+      category,
       snapId: snap.id,
       name: manifest.proposedName,
       description: getDescription(snap, manifest),
@@ -315,19 +325,24 @@ export const sourceNodes: GatsbyNode[`sourceNodes`] = async ({
 
       return result;
     },
-    new Set<string>(),
+    new Set<string>(Object.keys(LEGACY_CATEGORIES)),
   );
 
   for (const category of categories) {
+    // For legacy categories, we map to the new name.
+    const legacyMapping = LEGACY_CATEGORIES[category];
+
+    const categoryData = { name: category, legacyMapping };
+
     const node = {
-      name: category,
+      ...categoryData,
       parent: null,
       children: [],
       id: createNodeId(`category__${category}`),
       internal: {
         type: 'Category',
-        content: JSON.stringify(category),
-        contentDigest: createContentDigest(category),
+        content: JSON.stringify(categoryData),
+        contentDigest: createContentDigest(categoryData),
       },
     };
 
@@ -466,8 +481,9 @@ export const onCreateNode: GatsbyNode[`onCreateNode`] = async ({
     >;
 
     const { createNode, createNodeField } = actions;
+    const name = categoryNode.legacyMapping ?? categoryNode.name;
     const snaps = getNodesByType('Snap').filter(
-      (snap) => snap.category === categoryNode.name,
+      (snap) => snap.category === name,
     ) as unknown as Fields<Queries.Snap, keyof Queries.Snap>[];
 
     const banner = await generateCategoryImage(snaps);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,12 +53,12 @@ export const SNAP_CATEGORY_LINKS: Record<
   },
   [RegistrySnapCategory.Communication]: {
     header: defineMessage`Notifications and Chat`,
-    link: '/notifications',
+    link: '/communication',
     linkText: defineMessage`See All`,
   },
   [RegistrySnapCategory.Security]: {
     header: defineMessage`Guard Your Wallet`,
-    link: '/transaction-insights',
+    link: '/security',
     linkText: defineMessage`See All`,
   },
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,8 +4,8 @@ import { defineMessage } from '@lingui/macro';
 export enum RegistrySnapCategory {
   AccountManagement = 'account management',
   Interoperability = 'interoperability',
-  Notifications = 'notifications',
-  TransactionInsights = 'transaction insights',
+  Communication = 'communication',
+  Security = 'security',
 }
 
 export const SNAP_CATEGORY_LABELS: Record<
@@ -23,11 +23,11 @@ export const SNAP_CATEGORY_LABELS: Record<
     name: defineMessage`Interoperability`,
     description: defineMessage`Connect to non-Ethereum blockchains with MetaMask.`,
   },
-  [RegistrySnapCategory.Notifications]: {
+  [RegistrySnapCategory.Communication]: {
     name: defineMessage`Communication`,
     description: defineMessage`Stay in the know with notifications and chat directly in MetaMask.`,
   },
-  [RegistrySnapCategory.TransactionInsights]: {
+  [RegistrySnapCategory.Security]: {
     name: defineMessage`Security`,
     description: defineMessage`Guard your wallet with transaction insights and safety tools.`,
   },
@@ -51,12 +51,12 @@ export const SNAP_CATEGORY_LINKS: Record<
     link: '/interoperability',
     linkText: defineMessage`See All`,
   },
-  [RegistrySnapCategory.Notifications]: {
+  [RegistrySnapCategory.Communication]: {
     header: defineMessage`Notifications and Chat`,
     link: '/notifications',
     linkText: defineMessage`See All`,
   },
-  [RegistrySnapCategory.TransactionInsights]: {
+  [RegistrySnapCategory.Security]: {
     header: defineMessage`Guard Your Wallet`,
     link: '/transaction-insights',
     linkText: defineMessage`See All`,

--- a/src/features/filter/Filter.test.tsx
+++ b/src/features/filter/Filter.test.tsx
@@ -10,7 +10,7 @@ import { render } from '../../utils/test-utils';
 describe('Filter', () => {
   it('renders the enabled categories', async () => {
     const store = createStore();
-    store.dispatch(setCategory(RegistrySnapCategory.TransactionInsights));
+    store.dispatch(setCategory(RegistrySnapCategory.Security));
 
     const { queryByText } = render(<Filter />, store);
     expect(queryByText('Security')).toBeInTheDocument();
@@ -45,7 +45,7 @@ describe('Filter', () => {
   it('enables all categories and disabled installed when clicking "All"', () => {
     const store = createStore();
     store.dispatch(toggleInstalled());
-    store.dispatch(setCategory(RegistrySnapCategory.TransactionInsights));
+    store.dispatch(setCategory(RegistrySnapCategory.Security));
 
     const { queryByText, getByText, getByLabelText } = render(
       <Filter />,
@@ -72,7 +72,7 @@ describe('Filter', () => {
 
   it('enables the installed filter when clicking "Installed"', () => {
     const store = createStore();
-    store.dispatch(setCategory(RegistrySnapCategory.TransactionInsights));
+    store.dispatch(setCategory(RegistrySnapCategory.Security));
 
     const { queryByText, getByText, getByLabelText } = render(
       <Filter />,

--- a/src/features/filter/components/FilterCategory.test.tsx
+++ b/src/features/filter/components/FilterCategory.test.tsx
@@ -14,7 +14,7 @@ describe('FilterCategory', () => {
     const { queryByText, queryByLabelText } = render(
       <Menu>
         <FilterCategory
-          category={RegistrySnapCategory.TransactionInsights}
+          category={RegistrySnapCategory.Security}
           icon={TransactionInsightsIcon}
         />
       </Menu>,
@@ -29,22 +29,22 @@ describe('FilterCategory', () => {
     const { getByText } = render(
       <Menu>
         <FilterCategory
-          category={RegistrySnapCategory.TransactionInsights}
+          category={RegistrySnapCategory.Security}
           icon={TransactionInsightsIcon}
         />
       </Menu>,
       store,
     );
 
-    expect(
-      getCategory(RegistrySnapCategory.TransactionInsights)(store.getState()),
-    ).toBe(true);
+    expect(getCategory(RegistrySnapCategory.Security)(store.getState())).toBe(
+      true,
+    );
 
     const button = getByText('Security');
     act(() => button.click());
 
-    expect(
-      getCategory(RegistrySnapCategory.TransactionInsights)(store.getState()),
-    ).toBe(false);
+    expect(getCategory(RegistrySnapCategory.Security)(store.getState())).toBe(
+      false,
+    );
   });
 });

--- a/src/features/filter/components/FilterTag.test.tsx
+++ b/src/features/filter/components/FilterTag.test.tsx
@@ -9,7 +9,7 @@ import { getCategory } from '../store';
 describe('FilterTag', () => {
   it('renders', () => {
     const { queryByText } = render(
-      <FilterTag category={RegistrySnapCategory.TransactionInsights} />,
+      <FilterTag category={RegistrySnapCategory.Security} />,
     );
 
     expect(queryByText('Security')).toBeInTheDocument();
@@ -18,19 +18,19 @@ describe('FilterTag', () => {
   it('toggles the category when clicked', () => {
     const store = createStore();
     const { getByLabelText } = render(
-      <FilterTag category={RegistrySnapCategory.TransactionInsights} />,
+      <FilterTag category={RegistrySnapCategory.Security} />,
       store,
     );
 
-    expect(
-      getCategory(RegistrySnapCategory.TransactionInsights)(store.getState()),
-    ).toBe(true);
+    expect(getCategory(RegistrySnapCategory.Security)(store.getState())).toBe(
+      true,
+    );
 
     const button = getByLabelText('Close').parentElement;
     act(() => button?.click());
 
-    expect(
-      getCategory(RegistrySnapCategory.TransactionInsights)(store.getState()),
-    ).toBe(false);
+    expect(getCategory(RegistrySnapCategory.Security)(store.getState())).toBe(
+      false,
+    );
   });
 });

--- a/src/features/filter/components/FilterTags.test.tsx
+++ b/src/features/filter/components/FilterTags.test.tsx
@@ -10,7 +10,7 @@ import { setCategory, toggleInstalled } from '../store';
 describe('FilterTags', () => {
   it('renders the selected filters', async () => {
     const store = createStore();
-    store.dispatch(setCategory(RegistrySnapCategory.TransactionInsights));
+    store.dispatch(setCategory(RegistrySnapCategory.Security));
 
     const { queryByText } = render(<FilterTags />, store);
     expect(queryByText('Security')).toBeInTheDocument();

--- a/src/features/filter/constants.tsx
+++ b/src/features/filter/constants.tsx
@@ -15,8 +15,8 @@ export const SNAP_CATEGORY_ICONS: Record<
 > = {
   [RegistrySnapCategory.AccountManagement]: AddUserIcon,
   [RegistrySnapCategory.Interoperability]: InteroperabilityIcon,
-  [RegistrySnapCategory.Notifications]: NotificationsCategoryIcon,
-  [RegistrySnapCategory.TransactionInsights]: TransactionInsightsIcon,
+  [RegistrySnapCategory.Communication]: NotificationsCategoryIcon,
+  [RegistrySnapCategory.Security]: TransactionInsightsIcon,
 };
 
 export enum Order {

--- a/src/features/filter/store.test.ts
+++ b/src/features/filter/store.test.ts
@@ -92,7 +92,7 @@ describe('filterSlice', () => {
       const state = filterSlice.reducer(
         filterSlice.reducer(
           filterSlice.getInitialState(),
-          setCategory(RegistrySnapCategory.TransactionInsights),
+          setCategory(RegistrySnapCategory.Security),
         ),
         toggleInstalled(),
       );
@@ -107,15 +107,13 @@ describe('filterSlice', () => {
       const state = filterSlice.reducer(
         filterSlice.reducer(
           filterSlice.reducer(filterSlice.getInitialState(), toggleInstalled()),
-          setCategory(RegistrySnapCategory.TransactionInsights),
+          setCategory(RegistrySnapCategory.Security),
         ),
         toggleInstalled(),
       );
 
       expect(state.installed).toBe(false);
-      expect(state.categories).toStrictEqual([
-        RegistrySnapCategory.TransactionInsights,
-      ]);
+      expect(state.categories).toStrictEqual([RegistrySnapCategory.Security]);
     });
   });
 
@@ -123,21 +121,17 @@ describe('filterSlice', () => {
     it('toggles the category', () => {
       const state = filterSlice.reducer(
         filterSlice.getInitialState(),
-        toggleCategory(RegistrySnapCategory.TransactionInsights),
+        toggleCategory(RegistrySnapCategory.Security),
       );
 
-      expect(state.categories).not.toContain(
-        RegistrySnapCategory.TransactionInsights,
-      );
+      expect(state.categories).not.toContain(RegistrySnapCategory.Security);
 
       const newState = filterSlice.reducer(
         state,
-        toggleCategory(RegistrySnapCategory.TransactionInsights),
+        toggleCategory(RegistrySnapCategory.Security),
       );
 
-      expect(newState.categories).toContain(
-        RegistrySnapCategory.TransactionInsights,
-      );
+      expect(newState.categories).toContain(RegistrySnapCategory.Security);
     });
 
     it('sets the categories to all if all categories are toggled off', () => {
@@ -160,12 +154,10 @@ describe('filterSlice', () => {
     it('sets the category', () => {
       const state = filterSlice.reducer(
         filterSlice.getInitialState(),
-        setCategory(RegistrySnapCategory.TransactionInsights),
+        setCategory(RegistrySnapCategory.Security),
       );
 
-      expect(state.categories).toStrictEqual([
-        RegistrySnapCategory.TransactionInsights,
-      ]);
+      expect(state.categories).toStrictEqual([RegistrySnapCategory.Security]);
     });
   });
 
@@ -263,14 +255,14 @@ describe('filterSlice', () => {
         filter: {
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
+            RegistrySnapCategory.Communication,
           ],
         },
       });
 
       expect(getCategories(state)).toStrictEqual([
         RegistrySnapCategory.Interoperability,
-        RegistrySnapCategory.Notifications,
+        RegistrySnapCategory.Communication,
       ]);
     });
   });
@@ -281,7 +273,7 @@ describe('filterSlice', () => {
         filter: {
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
+            RegistrySnapCategory.Communication,
           ],
         },
       });
@@ -296,14 +288,12 @@ describe('filterSlice', () => {
         filter: {
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
+            RegistrySnapCategory.Communication,
           ],
         },
       });
 
-      expect(getCategory(RegistrySnapCategory.TransactionInsights)(state)).toBe(
-        false,
-      );
+      expect(getCategory(RegistrySnapCategory.Security)(state)).toBe(false);
     });
   });
 
@@ -337,8 +327,8 @@ describe('filterSlice', () => {
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
-            RegistrySnapCategory.TransactionInsights,
+            RegistrySnapCategory.Communication,
+            RegistrySnapCategory.Security,
           ],
           order: Order.Popularity,
         },
@@ -387,8 +377,8 @@ describe('filterSlice', () => {
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
-            RegistrySnapCategory.TransactionInsights,
+            RegistrySnapCategory.Communication,
+            RegistrySnapCategory.Security,
           ],
           order: Order.Popularity,
         },
@@ -431,8 +421,8 @@ describe('filterSlice', () => {
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
-            RegistrySnapCategory.TransactionInsights,
+            RegistrySnapCategory.Communication,
+            RegistrySnapCategory.Security,
           ],
           order: Order.Popularity,
         },
@@ -478,8 +468,8 @@ describe('filterSlice', () => {
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
-            RegistrySnapCategory.TransactionInsights,
+            RegistrySnapCategory.Communication,
+            RegistrySnapCategory.Security,
           ],
           order: Order.Popularity,
         },
@@ -516,8 +506,8 @@ describe('filterSlice', () => {
           installed: true,
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
-            RegistrySnapCategory.TransactionInsights,
+            RegistrySnapCategory.Communication,
+            RegistrySnapCategory.Security,
           ],
           order: Order.Popularity,
         },
@@ -541,7 +531,7 @@ describe('filterSlice', () => {
     it('returns the Snaps within the selected categories', () => {
       const { snap: fooSnap } = getMockSnap({
         snapId: 'foo-snap',
-        category: RegistrySnapCategory.Notifications,
+        category: RegistrySnapCategory.Communication,
       });
 
       const { snap: barSnap } = getMockSnap({
@@ -551,7 +541,7 @@ describe('filterSlice', () => {
 
       const { snap: bazSnap } = getMockSnap({
         snapId: 'baz-snap',
-        category: RegistrySnapCategory.TransactionInsights,
+        category: RegistrySnapCategory.Security,
       });
 
       const state = getMockState({
@@ -560,8 +550,8 @@ describe('filterSlice', () => {
           searchResults: [],
           installed: false,
           categories: [
-            RegistrySnapCategory.Notifications,
-            RegistrySnapCategory.TransactionInsights,
+            RegistrySnapCategory.Communication,
+            RegistrySnapCategory.Security,
           ],
           order: Order.Popularity,
         },
@@ -609,8 +599,8 @@ describe('filterSlice', () => {
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
-            RegistrySnapCategory.TransactionInsights,
+            RegistrySnapCategory.Communication,
+            RegistrySnapCategory.Security,
           ],
           order: Order.Alphabetical,
         },
@@ -665,8 +655,8 @@ describe('filterSlice', () => {
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
-            RegistrySnapCategory.TransactionInsights,
+            RegistrySnapCategory.Communication,
+            RegistrySnapCategory.Security,
           ],
           order: Order.Popularity,
         },
@@ -718,8 +708,8 @@ describe('filterSlice', () => {
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
-            RegistrySnapCategory.TransactionInsights,
+            RegistrySnapCategory.Communication,
+            RegistrySnapCategory.Security,
           ],
           order: Order.DeterministicRandom,
         },
@@ -771,8 +761,8 @@ describe('filterSlice', () => {
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
-            RegistrySnapCategory.TransactionInsights,
+            RegistrySnapCategory.Communication,
+            RegistrySnapCategory.Security,
           ],
           order: Order.Random,
         },
@@ -825,8 +815,8 @@ describe('filterSlice', () => {
           installed: false,
           categories: [
             RegistrySnapCategory.Interoperability,
-            RegistrySnapCategory.Notifications,
-            RegistrySnapCategory.TransactionInsights,
+            RegistrySnapCategory.Communication,
+            RegistrySnapCategory.Security,
           ],
           order: Order.Latest,
         },

--- a/src/features/snap/components/Category.test.tsx
+++ b/src/features/snap/components/Category.test.tsx
@@ -5,7 +5,7 @@ import { render } from '../../../utils/test-utils';
 describe('Category', () => {
   it('renders the correct category name', () => {
     const { queryByText } = render(
-      <Category category={RegistrySnapCategory.TransactionInsights} />,
+      <Category category={RegistrySnapCategory.Security} />,
     );
 
     expect(queryByText('Security')).toBeInTheDocument();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -38,21 +38,19 @@ const GROUPS = [
     order: Order.DeterministicRandom,
   },
   {
-    header:
-      SNAP_CATEGORY_LINKS[RegistrySnapCategory.TransactionInsights].header,
-    category: RegistrySnapCategory.TransactionInsights,
+    header: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Security].header,
+    category: RegistrySnapCategory.Security,
     limit: 6,
-    link: SNAP_CATEGORY_LINKS[RegistrySnapCategory.TransactionInsights].link,
-    linkText:
-      SNAP_CATEGORY_LINKS[RegistrySnapCategory.TransactionInsights].linkText,
+    link: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Security].link,
+    linkText: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Security].linkText,
     order: Order.DeterministicRandom,
   },
   {
-    header: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Notifications].header,
-    category: RegistrySnapCategory.Notifications,
+    header: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Communication].header,
+    category: RegistrySnapCategory.Communication,
     limit: 3,
-    link: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Notifications].link,
-    linkText: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Notifications].linkText,
+    link: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Communication].link,
+    linkText: SNAP_CATEGORY_LINKS[RegistrySnapCategory.Communication].linkText,
     order: Order.DeterministicRandom,
   },
   {

--- a/src/pages/{Category.name}/index.tsx
+++ b/src/pages/{Category.name}/index.tsx
@@ -16,14 +16,15 @@ export type CategoryProps = {
     locale: string;
   };
   data: {
-    category: Fields<Queries.Category, 'name' | 'banner'>;
+    category: Fields<Queries.Category, 'name' | 'banner' | 'legacyMapping'>;
   };
 };
 
 const Head: FunctionComponent<CategoryProps> = ({ data, pageContext }) => {
   const { _ } = useLingui();
 
-  const category = data.category.name as RegistrySnapCategory;
+  const category = (data.category.legacyMapping ??
+    data.category.name) as RegistrySnapCategory;
   const { name, description } = SNAP_CATEGORY_LABELS[category];
 
   const nameText = _(name);
@@ -56,14 +57,16 @@ const Head: FunctionComponent<CategoryProps> = ({ data, pageContext }) => {
 const Category: FunctionComponent<CategoryProps> = ({ data, pageContext }) => {
   const dispatch = useDispatch();
 
+  const categoryName = data.category.legacyMapping ?? data.category.name;
+
   useEffect(() => {
-    dispatch(setCategory(data.category.name as RegistrySnapCategory));
+    dispatch(setCategory(categoryName as RegistrySnapCategory));
 
     // According to the type definition, `navigate` returns a promise, but in
     // practice it does not.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     navigate('/explore', { replace: true });
-  }, [data.category.name, dispatch]);
+  }, [categoryName, dispatch]);
 
   return <Head data={data} pageContext={pageContext} />;
 };
@@ -72,6 +75,7 @@ export const query = graphql`
   query ($id: String) {
     category(id: { eq: $id }) {
       name
+      legacyMapping
       banner {
         publicURL
       }

--- a/src/pages/{Category.name}/installed.tsx
+++ b/src/pages/{Category.name}/installed.tsx
@@ -16,7 +16,10 @@ export type CategoryInstalledProps = {
     locale: string;
   };
   data: {
-    category: Fields<Queries.Category, 'name' | 'installedBanner'>;
+    category: Fields<
+      Queries.Category,
+      'name' | 'installedBanner' | 'legacyMapping'
+    >;
   };
 };
 
@@ -26,7 +29,8 @@ const Head: FunctionComponent<CategoryInstalledProps> = ({
 }) => {
   const { _ } = useLingui();
 
-  const category = data.category.name as RegistrySnapCategory;
+  const category = (data.category.legacyMapping ??
+    data.category.name) as RegistrySnapCategory;
   const { name } = SNAP_CATEGORY_LABELS[category];
 
   const nameText = _(name);
@@ -66,9 +70,11 @@ const CategoryInstalled: FunctionComponent<CategoryInstalledProps> = ({
 }) => {
   const dispatch = useDispatch();
 
+  const categoryName = data.category.legacyMapping ?? data.category.name;
+
   useEffect(() => {
     dispatch(toggleInstalled());
-    dispatch(setCategory(data.category.name as RegistrySnapCategory));
+    dispatch(setCategory(categoryName as RegistrySnapCategory));
 
     // According to the type definition, `navigate` returns a promise, but in
     // practice it does not.
@@ -83,6 +89,7 @@ export const query = graphql`
   query ($id: String) {
     category(id: { eq: $id }) {
       name
+      legacyMapping
       installedBanner {
         publicURL
       }

--- a/src/pages/{Category.name}/installed.tsx
+++ b/src/pages/{Category.name}/installed.tsx
@@ -80,7 +80,7 @@ const CategoryInstalled: FunctionComponent<CategoryInstalledProps> = ({
     // practice it does not.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     navigate('/explore', { replace: true });
-  }, [data.category.name, dispatch]);
+  }, [categoryName, dispatch]);
 
   return <Head data={data} pageContext={pageContext} />;
 };

--- a/src/utils/test-utils/queries.ts
+++ b/src/utils/test-utils/queries.ts
@@ -319,7 +319,7 @@ export function getMockSnap({
   latestVersion = '1.0.0',
   website = 'https://example.com',
   onboard = false,
-  category = RegistrySnapCategory.TransactionInsights,
+  category = RegistrySnapCategory.Security,
   author = {
     name: 'Author',
     website: 'https://example.com/author',
@@ -403,7 +403,7 @@ export type GetMockCategoryArgs = {
  * @returns The mock category data.
  */
 export function getMockCategory({
-  name = RegistrySnapCategory.TransactionInsights,
+  name = RegistrySnapCategory.Security,
   banner = {
     publicURL: 'https://example.com/banner.png',
   },


### PR DESCRIPTION
Add support for migrating between the legacy and new category names. This effectively allows Snaps to use either a legacy category name or a new one without breaking the app. The legacy category names are replaced using a mapping a build time, but the keeps the URLs for the legacy categories alive. The legacy URLs redirect to the new category page.

Also actually changes the underlying constants for the categories.