### PR TITLE
Update GitHub Actions to latest versions and use OIDC for deploying

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -8,9 +8,9 @@ jobs:
     name: Prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -23,9 +23,9 @@ jobs:
     needs:
       - prepare
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -56,9 +56,9 @@ jobs:
     needs:
       - prepare
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -81,9 +81,9 @@ jobs:
       matrix:
         node-version: [16.x, 18.x, 20.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # This is to guarantee that the most recent tag is fetched.
           # This can be configured to a more reasonable value by consumers.
@@ -30,10 +30,10 @@ jobs:
           # branch for all git operations and the release PR.
           ref: ${{ github.event.inputs.base-branch }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-      - uses: MetaMask/action-create-release-pr@v1
+      - uses: MetaMask/action-create-release-pr@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     runs-on: ubuntu-latest
     steps:
-      - uses: MetaMask/action-is-release@v1
+      - uses: MetaMask/action-is-release@v2
         id: is-release
 
   publish-release:
@@ -79,10 +79,11 @@ jobs:
     name: Publish release
     permissions:
       contents: write
+      pages: write
+      id-token: write
     uses: ./.github/workflows/publish-release.yml
     with:
       slack-subteam: S05RL9W7H54 # @metamask-snaps-publishers
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}
       SEGMENT_PRODUCTION_WRITE_KEY: ${{ secrets.SEGMENT_PRODUCTION_WRITE_KEY }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,8 +21,6 @@ on:
     secrets:
       SLACK_WEBHOOK_URL:
         required: false
-      PUBLISH_PAGES_TOKEN:
-        required: true
       SEGMENT_PRODUCTION_WRITE_KEY:
         required: true
 
@@ -31,7 +29,7 @@ jobs:
     name: Announce release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: name-version
         name: Get Slack name and version
         shell: bash
@@ -76,14 +74,14 @@ jobs:
     needs:
       - announce-release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-      - uses: MetaMask/action-publish-release@v2
+      - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -92,10 +90,11 @@ jobs:
     needs:
       - publish-release
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
     uses: ./.github/workflows/publish-site.yml
     with:
       destination_dir: .
     secrets:
-      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}
       SEGMENT_PRODUCTION_WRITE_KEY: ${{ secrets.SEGMENT_PRODUCTION_WRITE_KEY }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -94,7 +94,5 @@ jobs:
       pages: write
       id-token: write
     uses: ./.github/workflows/publish-site.yml
-    with:
-      destination_dir: .
     secrets:
       SEGMENT_PRODUCTION_WRITE_KEY: ${{ secrets.SEGMENT_PRODUCTION_WRITE_KEY }}

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -27,9 +27,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Ensure `destination_dir` is not empty
-        if: ${{ inputs.destination_dir == '' }}
-        run: exit 1
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -26,8 +26,6 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    permissions:
-      contents: write
     steps:
       - name: Ensure `destination_dir` is not empty
         if: ${{ inputs.destination_dir == '' }}

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -3,23 +3,29 @@ name: Publish site to GitHub Pages
 on:
   workflow_call:
     inputs:
-      destination_dir:
-        required: true
-        type: string
       ref:
         required: false
         type: string
     secrets:
-      PUBLISH_PAGES_TOKEN:
-        required: true
       SEGMENT_PRODUCTION_WRITE_KEY:
         required: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   publish-site-to-gh-pages:
     name: Publish site to GitHub Pages
     runs-on: ubuntu-latest
-    environment: github-pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     permissions:
       contents: write
     steps:
@@ -27,11 +33,11 @@ jobs:
         if: ${{ inputs.destination_dir == '' }}
         run: exit 1
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -41,9 +47,12 @@ jobs:
         run: yarn build
         env:
           SEGMENT_PRODUCTION_WRITE_KEY: ${{ secrets.SEGMENT_PRODUCTION_WRITE_KEY }}
-      - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
-        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          personal_token: ${{ secrets.PUBLISH_PAGES_TOKEN }}
-          publish_dir: ./public
-          destination_dir: ${{ inputs.destination_dir }}
+          path: public
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-staging-site.yml
+++ b/.github/workflows/publish-staging-site.yml
@@ -20,9 +20,9 @@ jobs:
         if: ${{ inputs.destination_dir == '' }}
         run: exit 1
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -107,7 +107,6 @@ jobs:
       id-token: write
     uses: ./.github/workflows/publish-site.yml
     with:
-      destination_dir: .
       ref: ${{ needs.get-release-tag.outputs.tag }}
     secrets:
       SEGMENT_PRODUCTION_WRITE_KEY: ${{ secrets.SEGMENT_PRODUCTION_WRITE_KEY }}

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -46,7 +46,7 @@ jobs:
     needs:
       - get-release-tag
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.get-release-tag.outputs.tag }}
       - id: name-version
@@ -102,11 +102,12 @@ jobs:
       - get-release-tag
       - publish-release
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
     uses: ./.github/workflows/publish-site.yml
     with:
       destination_dir: .
       ref: ${{ needs.get-release-tag.outputs.tag }}
     secrets:
-      PUBLISH_PAGES_TOKEN: ${{ secrets.PUBLISH_PAGES_TOKEN }}
       SEGMENT_PRODUCTION_WRITE_KEY: ${{ secrets.SEGMENT_PRODUCTION_WRITE_KEY }}


### PR DESCRIPTION
This bumps a bunch of GitHub Actions to the latest versions, and also removes the need for `PUBLISH_PAGES_TOKEN` in favour of using OIDC for deployment to GitHub Pages.