### PR TITLE
Show install numbers in modal

### DIFF
--- a/src/components/InstallationCount.test.tsx
+++ b/src/components/InstallationCount.test.tsx
@@ -13,4 +13,20 @@ describe('InstallationCount', () => {
 
     expect(queryByText('< 1K installs')).toBeInTheDocument();
   });
+
+  it('renders specific format for more than a thousand installs in minimal variant', async () => {
+    const { queryByText } = render(
+      <InstallationCount minimal={true} installs={1_000_000} />,
+    );
+
+    expect(queryByText('1M')).toBeInTheDocument();
+  });
+
+  it('renders specific format for less  than a thousand installs in minimal variant', async () => {
+    const { queryByText } = render(
+      <InstallationCount minimal={true} installs={999} />,
+    );
+
+    expect(queryByText('< 1K')).toBeInTheDocument();
+  });
 });

--- a/src/components/InstallationCount.tsx
+++ b/src/components/InstallationCount.tsx
@@ -7,22 +7,34 @@ import { useLocale } from '../hooks';
 
 type InstallationCountProps = {
   installs: number;
+  minimal?: boolean;
+  color?: string;
 };
 
 export const InstallationCount: FunctionComponent<InstallationCountProps> = ({
   installs,
+  minimal = false,
+  color = 'icon.muted',
 }) => {
   const { locale } = useLocale();
   const { _ } = useLingui();
 
+  const formattedNumber = new Intl.NumberFormat(locale, {
+    notation: 'compact',
+  }).format(installs);
+
+  if (minimal) {
+    return (
+      <Text color={color}>
+        {installs >= 1000 ? formattedNumber : _(t`< 1K`)}
+      </Text>
+    );
+  }
+
   return (
-    <Text color="icon.muted">
+    <Text color={color}>
       {installs >= 1000
-        ? _(
-            t`${new Intl.NumberFormat(locale, { notation: 'compact' }).format(
-              installs,
-            )} installs`,
-          )
+        ? _(t`${formattedNumber} installs`)
         : _(t`< 1K installs`)}
     </Text>
   );

--- a/src/features/snap/components/MetadataModal.tsx
+++ b/src/features/snap/components/MetadataModal.tsx
@@ -5,6 +5,7 @@ import {
   ModalCloseButton,
   ModalContent,
   ModalOverlay,
+  Text,
 } from '@chakra-ui/react';
 import { t, Trans } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
@@ -15,6 +16,7 @@ import { Data } from './Data';
 import { Legal } from './Legal';
 import { MetadataItems } from './MetadataItems';
 import { SourceCode } from './SourceCode';
+import { InstallationCount } from '../../../components';
 import type { Fields } from '../../../utils';
 
 export type MetadataModalProps = {
@@ -31,6 +33,7 @@ export type MetadataModalProps = {
     | 'privateCode'
     | 'privacyPolicy'
     | 'termsOfUse'
+    | 'installs'
   >;
   isOpen: boolean;
   onClose: () => void;
@@ -52,6 +55,7 @@ export const MetadataModal: FunctionComponent<MetadataModalProps> = ({
     privateCode,
     privacyPolicy,
     termsOfUse,
+    installs,
   } = snap;
 
   return (
@@ -67,7 +71,17 @@ export const MetadataModal: FunctionComponent<MetadataModalProps> = ({
         <ModalBody display="flex" flexDirection="column" gap="4">
           <MetadataItems snap={snap} />
 
-          <Data label={_(t`Version`)} value={latestVersion} />
+          <Data label={_(t`Version`)} value={<Text>{latestVersion}</Text>} />
+          <Data
+            label={_(t`Installs`)}
+            value={
+              <InstallationCount
+                color="text.default"
+                minimal={true}
+                installs={installs}
+              />
+            }
+          />
           {sourceCode && (
             <Data
               label={_(t`Source Code`)}

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -18,13 +18,13 @@ msgstr ""
 "X-Crowdin-File: /src/locales/en-US/messages.po\n"
 "X-Crowdin-File-ID: 1546\n"
 
-#: src/components/InstallationCount.tsx
-msgid "{0} installs"
-msgstr ""
-
 #: src/pages/snap/{Snap.location}/{Snap.slug}.tsx
 msgid "{0} on the MetaMask Snaps Directory"
 msgstr "{0} im MetaMask Snaps Directory"
+
+#: src/components/InstallationCount.tsx
+msgid "{formattedNumber} installs"
+msgstr ""
 
 #: src/components/PostInstallModal.tsx
 msgid "{name} is now ready to use."
@@ -41,6 +41,10 @@ msgstr "{nameText}-Snaps im MetaMask Snaps Directory"
 #: src/components/FooterCopyright.tsx
 msgid "©{0} MetaMask. All rights reserved."
 msgstr "©{0} MetaMask. Alle Rechte vorbehalten."
+
+#: src/components/InstallationCount.tsx
+msgid "< 1K"
+msgstr ""
 
 #: src/components/InstallationCount.tsx
 msgid "< 1K installs"
@@ -480,6 +484,10 @@ msgstr "Installierte Snaps im MetaMask Snaps Directory"
 #: src/components/InstallSnapButton.tsx
 msgid "Installing {name}"
 msgstr "Installation von {name}"
+
+#: src/features/snap/components/MetadataModal.tsx
+msgid "Installs"
+msgstr ""
 
 #: src/components/icons/index.ts
 #: src/constants.ts

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/InstallationCount.tsx
-msgid "{0} installs"
-msgstr "{0} installs"
-
 #: src/pages/snap/{Snap.location}/{Snap.slug}.tsx
 msgid "{0} on the MetaMask Snaps Directory"
 msgstr "{0} on the MetaMask Snaps Directory"
+
+#: src/components/InstallationCount.tsx
+msgid "{formattedNumber} installs"
+msgstr "{formattedNumber} installs"
 
 #: src/components/PostInstallModal.tsx
 msgid "{name} is now ready to use."
@@ -36,6 +36,10 @@ msgstr "{nameText} Snaps on the MetaMask Snaps Directory"
 #: src/components/FooterCopyright.tsx
 msgid "©{0} MetaMask. All rights reserved."
 msgstr ""
+
+#: src/components/InstallationCount.tsx
+msgid "< 1K"
+msgstr "< 1K"
 
 #: src/components/InstallationCount.tsx
 msgid "< 1K installs"
@@ -475,6 +479,10 @@ msgstr "Installed Snaps on the MetaMask Snaps Directory"
 #: src/components/InstallSnapButton.tsx
 msgid "Installing {name}"
 msgstr ""
+
+#: src/features/snap/components/MetadataModal.tsx
+msgid "Installs"
+msgstr "Installs"
 
 #: src/components/icons/index.ts
 #: src/constants.ts

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -18,13 +18,13 @@ msgstr ""
 "X-Crowdin-File: /src/locales/en-US/messages.po\n"
 "X-Crowdin-File-ID: 1546\n"
 
-#: src/components/InstallationCount.tsx
-msgid "{0} installs"
-msgstr ""
-
 #: src/pages/snap/{Snap.location}/{Snap.slug}.tsx
 msgid "{0} on the MetaMask Snaps Directory"
 msgstr "MetaMask Snaps Directoryの{0}"
+
+#: src/components/InstallationCount.tsx
+msgid "{formattedNumber} installs"
+msgstr ""
 
 #: src/components/PostInstallModal.tsx
 msgid "{name} is now ready to use."
@@ -41,6 +41,10 @@ msgstr "MetaMask Snaps Directoryの{nameText} Snap"
 #: src/components/FooterCopyright.tsx
 msgid "©{0} MetaMask. All rights reserved."
 msgstr "©{0} MetaMask. 不許複製。"
+
+#: src/components/InstallationCount.tsx
+msgid "< 1K"
+msgstr ""
 
 #: src/components/InstallationCount.tsx
 msgid "< 1K installs"
@@ -480,6 +484,10 @@ msgstr "MetaMask Snaps DirectoryのインストールされたSnap"
 #: src/components/InstallSnapButton.tsx
 msgid "Installing {name}"
 msgstr "{name}をインストールしています"
+
+#: src/features/snap/components/MetadataModal.tsx
+msgid "Installs"
+msgstr ""
 
 #: src/components/icons/index.ts
 #: src/constants.ts

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -18,13 +18,13 @@ msgstr ""
 "X-Crowdin-File: /src/locales/en-US/messages.po\n"
 "X-Crowdin-File-ID: 1546\n"
 
-#: src/components/InstallationCount.tsx
-msgid "{0} installs"
-msgstr ""
-
 #: src/pages/snap/{Snap.location}/{Snap.slug}.tsx
 msgid "{0} on the MetaMask Snaps Directory"
 msgstr "{0} no Diretório do MetaMask Snaps"
+
+#: src/components/InstallationCount.tsx
+msgid "{formattedNumber} installs"
+msgstr ""
 
 #: src/components/PostInstallModal.tsx
 msgid "{name} is now ready to use."
@@ -41,6 +41,10 @@ msgstr "Snaps {nameText} no Diretório do MetaMask Snaps"
 #: src/components/FooterCopyright.tsx
 msgid "©{0} MetaMask. All rights reserved."
 msgstr "©{0} MetaMask. Todos os direitos reservados."
+
+#: src/components/InstallationCount.tsx
+msgid "< 1K"
+msgstr ""
 
 #: src/components/InstallationCount.tsx
 msgid "< 1K installs"
@@ -480,6 +484,10 @@ msgstr "Snaps instalados no Diretório do MetaMask Snaps"
 #: src/components/InstallSnapButton.tsx
 msgid "Installing {name}"
 msgstr "Instalando {name}"
+
+#: src/features/snap/components/MetadataModal.tsx
+msgid "Installs"
+msgstr ""
 
 #: src/components/icons/index.ts
 #: src/constants.ts

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -18,13 +18,13 @@ msgstr ""
 "X-Crowdin-File: /src/locales/en-US/messages.po\n"
 "X-Crowdin-File-ID: 1546\n"
 
-#: src/components/InstallationCount.tsx
-msgid "{0} installs"
-msgstr ""
-
 #: src/pages/snap/{Snap.location}/{Snap.slug}.tsx
 msgid "{0} on the MetaMask Snaps Directory"
 msgstr "{0} в Каталоге MetaMask Snaps"
+
+#: src/components/InstallationCount.tsx
+msgid "{formattedNumber} installs"
+msgstr ""
 
 #: src/components/PostInstallModal.tsx
 msgid "{name} is now ready to use."
@@ -41,6 +41,10 @@ msgstr "Snaps {nameText} в Каталоге MetaMask Snaps"
 #: src/components/FooterCopyright.tsx
 msgid "©{0} MetaMask. All rights reserved."
 msgstr "©{0} MetaMask. Все права защищены."
+
+#: src/components/InstallationCount.tsx
+msgid "< 1K"
+msgstr ""
 
 #: src/components/InstallationCount.tsx
 msgid "< 1K installs"
@@ -480,6 +484,10 @@ msgstr "Установленные Snaps в Каталоге MetaMask Snaps"
 #: src/components/InstallSnapButton.tsx
 msgid "Installing {name}"
 msgstr "Выполняется установка {name}"
+
+#: src/features/snap/components/MetadataModal.tsx
+msgid "Installs"
+msgstr ""
 
 #: src/components/icons/index.ts
 #: src/constants.ts

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -18,13 +18,13 @@ msgstr ""
 "X-Crowdin-File: /src/locales/en-US/messages.po\n"
 "X-Crowdin-File-ID: 1546\n"
 
-#: src/components/InstallationCount.tsx
-msgid "{0} installs"
-msgstr ""
-
 #: src/pages/snap/{Snap.location}/{Snap.slug}.tsx
 msgid "{0} on the MetaMask Snaps Directory"
 msgstr "MetaMask Snaps Dizinindeki {0}"
+
+#: src/components/InstallationCount.tsx
+msgid "{formattedNumber} installs"
+msgstr ""
 
 #: src/components/PostInstallModal.tsx
 msgid "{name} is now ready to use."
@@ -41,6 +41,10 @@ msgstr "MetaMask Snaps Dizinindeki {nameText} Snap'leri"
 #: src/components/FooterCopyright.tsx
 msgid "©{0} MetaMask. All rights reserved."
 msgstr "©{0} MetaMask. Tüm hakları saklıdır."
+
+#: src/components/InstallationCount.tsx
+msgid "< 1K"
+msgstr ""
 
 #: src/components/InstallationCount.tsx
 msgid "< 1K installs"
@@ -480,6 +484,10 @@ msgstr "MetaMask Snaps Dizininde yüklü Snap'ler"
 #: src/components/InstallSnapButton.tsx
 msgid "Installing {name}"
 msgstr "{name} yükleniyor"
+
+#: src/features/snap/components/MetadataModal.tsx
+msgid "Installs"
+msgstr ""
 
 #: src/components/icons/index.ts
 #: src/constants.ts

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -18,13 +18,13 @@ msgstr ""
 "X-Crowdin-File: /src/locales/en-US/messages.po\n"
 "X-Crowdin-File-ID: 1546\n"
 
-#: src/components/InstallationCount.tsx
-msgid "{0} installs"
-msgstr ""
-
 #: src/pages/snap/{Snap.location}/{Snap.slug}.tsx
 msgid "{0} on the MetaMask Snaps Directory"
 msgstr "MetaMask Snaps 目录上的 {0}"
+
+#: src/components/InstallationCount.tsx
+msgid "{formattedNumber} installs"
+msgstr ""
 
 #: src/components/PostInstallModal.tsx
 msgid "{name} is now ready to use."
@@ -41,6 +41,10 @@ msgstr "MetaMask Snaps 目录上的 {nameText} Snap"
 #: src/components/FooterCopyright.tsx
 msgid "©{0} MetaMask. All rights reserved."
 msgstr "© {0} MetaMask。保留所有权利。"
+
+#: src/components/InstallationCount.tsx
+msgid "< 1K"
+msgstr ""
 
 #: src/components/InstallationCount.tsx
 msgid "< 1K installs"
@@ -480,6 +484,10 @@ msgstr "已在 MetaMask Snaps 目录上安装的 Snap"
 #: src/components/InstallSnapButton.tsx
 msgid "Installing {name}"
 msgstr "正在安装 {name}"
+
+#: src/features/snap/components/MetadataModal.tsx
+msgid "Installs"
+msgstr ""
 
 #: src/components/icons/index.ts
 #: src/constants.ts


### PR DESCRIPTION
Add installation numbers to the metadata modal as well.

Fixes #379 