### PR TITLE
Use `wallet_getAllSnaps` and revoke permissions post-install

### DIFF
--- a/src/components/InstallSnapButton.test.tsx
+++ b/src/components/InstallSnapButton.test.tsx
@@ -16,7 +16,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: {},
+        wallet_getAllSnaps: {},
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),
@@ -35,7 +35,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: new Error('Snaps are not supported.'),
+        wallet_getAllSnaps: new Error('Snaps are not supported.'),
         web3_clientVersion: 'MetaMask/v10.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),
@@ -55,7 +55,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: {},
+        wallet_getAllSnaps: {},
         web3_clientVersion: 'MetaMask/v11.0.0',
         wallet_requestSnaps: {
           [snap.snapId]: {
@@ -91,7 +91,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: {},
+        wallet_getAllSnaps: {},
         web3_clientVersion: 'MetaMask/v11.0.0',
         wallet_requestSnaps: new Error('User rejected the request.'),
         /* eslint-enable @typescript-eslint/naming-convention */
@@ -123,7 +123,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: {
+        wallet_getAllSnaps: {
           [snap.snapId]: {
             name: snap.name,
             version: '0.1.0',
@@ -153,7 +153,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: {
+        wallet_getAllSnaps: {
           [snap.snapId]: {
             name: snap.name,
             version: snap.latestVersion,

--- a/src/components/InstallSnapButton.tsx
+++ b/src/components/InstallSnapButton.tsx
@@ -9,7 +9,8 @@ import { PostInstallModal } from './PostInstallModal';
 import {
   getUpdateAvailable,
   removeAcknowledgedUpdate,
-  useGetInstalledSnapsQuery,
+  useGetAllInstalledSnapsQuery,
+  useRevokePermissionsMutation,
   useInstallSnapMutation,
 } from '../features';
 import {
@@ -105,8 +106,9 @@ export const InstallSnapButton: FunctionComponent<InstallSnapButtonProps> = ({
   website,
   version,
 }) => {
-  const { data: installedSnaps } = useGetInstalledSnapsQuery();
+  const { data: installedSnaps } = useGetAllInstalledSnapsQuery();
   const [installSnap, { isLoading }] = useInstallSnapMutation();
+  const [revokePermissions] = useRevokePermissionsMutation();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const isSupportedVersion = useSupportedVersion();
   const updateAvailable = useSelector(getUpdateAvailable(snapId));
@@ -116,11 +118,11 @@ export const InstallSnapButton: FunctionComponent<InstallSnapButtonProps> = ({
 
   const handleInstall = () => {
     installSnap({ snapId, version })
-      .then((result) => {
+      .then(async (result) => {
         if ('error' in result) {
           return;
         }
-
+        await revokePermissions();
         dispatch(removeAcknowledgedUpdate(snapId));
         onOpen();
       })

--- a/src/features/filter/store.test.ts
+++ b/src/features/filter/store.test.ts
@@ -337,7 +337,7 @@ describe('filterSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [fooSnap.snapId]: {
                 version: fooSnap.latestVersion,
               },
@@ -387,7 +387,7 @@ describe('filterSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [fooSnap.snapId]: {
                 version: fooSnap.latestVersion,
               },
@@ -431,7 +431,7 @@ describe('filterSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [fooSnap.snapId]: {
                 version: fooSnap.latestVersion,
               },
@@ -478,7 +478,7 @@ describe('filterSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [fooSnap.snapId]: {
                 version: fooSnap.latestVersion,
               },
@@ -516,7 +516,7 @@ describe('filterSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [fooSnap.snapId]: {
                 version: fooSnap.latestVersion,
               },
@@ -560,7 +560,7 @@ describe('filterSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [fooSnap.snapId]: {
                 version: fooSnap.latestVersion,
               },
@@ -609,7 +609,7 @@ describe('filterSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [fooSnap.snapId]: {
                 version: fooSnap.latestVersion,
               },
@@ -665,7 +665,7 @@ describe('filterSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [fooSnap.snapId]: {
                 version: fooSnap.latestVersion,
               },
@@ -718,7 +718,7 @@ describe('filterSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [fooSnap.snapId]: {
                 version: fooSnap.latestVersion,
               },
@@ -771,7 +771,7 @@ describe('filterSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [fooSnap.snapId]: {
                 version: fooSnap.latestVersion,
               },
@@ -825,7 +825,7 @@ describe('filterSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [barSnap.snapId]: {
                 version: barSnap.latestVersion,
               },

--- a/src/features/filter/store.ts
+++ b/src/features/filter/store.ts
@@ -6,7 +6,7 @@ import { SORT_FUNCTIONS } from './sort';
 import { RegistrySnapCategory } from '../../constants';
 import type { ApplicationState } from '../../store';
 import type { Snap } from '../snaps';
-import { getInstalledSnaps, getSnapsById } from '../snaps';
+import { getAllInstalledSnaps, getSnapsById } from '../snaps';
 
 export type FilterState = {
   searchQuery: string;
@@ -146,7 +146,7 @@ export const getFilteredSnaps = createSelector(
 
     const sortedSnaps = SORT_FUNCTIONS[order](searchedSnaps);
 
-    const installedSnaps = getInstalledSnaps(state);
+    const installedSnaps = getAllInstalledSnaps(state);
     const filteredSnaps = installed
       ? sortedSnaps.filter((snap) => Boolean(installedSnaps[snap.snapId]))
       : sortedSnaps;

--- a/src/features/notifications/components/NotificationAcknowledger.test.tsx
+++ b/src/features/notifications/components/NotificationAcknowledger.test.tsx
@@ -21,7 +21,7 @@ describe('NotificationAcknowledger', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: {
+        wallet_getAllSnaps: {
           [snap.snapId]: {
             name: snap.name,
             version: '0.1.0',
@@ -58,7 +58,7 @@ describe('NotificationAcknowledger', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: {
+        wallet_getAllSnaps: {
           [snap.snapId]: {
             name: snap.name,
             version: '0.1.0',
@@ -93,7 +93,7 @@ describe('NotificationAcknowledger', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: {
+        wallet_getAllSnaps: {
           [snap.snapId]: {
             name: snap.name,
             version: '0.1.0',

--- a/src/features/notifications/components/NotificationsButton.test.tsx
+++ b/src/features/notifications/components/NotificationsButton.test.tsx
@@ -23,7 +23,7 @@ describe('NotificationsButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: {
+        wallet_getAllSnaps: {
           [snap.snapId]: {
             name: snap.name,
             version: '0.1.0',

--- a/src/features/notifications/components/NotificationsList.test.tsx
+++ b/src/features/notifications/components/NotificationsList.test.tsx
@@ -18,7 +18,7 @@ describe('NotificationsList', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: {
+        wallet_getAllSnaps: {
           [fooSnap.snapId]: {
             name: fooSnap.name,
             version: '0.1.0',

--- a/src/features/notifications/store.test.ts
+++ b/src/features/notifications/store.test.ts
@@ -178,7 +178,7 @@ describe('notificationsSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [snap.snapId]: {
                 version: '1.0.0',
               },
@@ -210,7 +210,7 @@ describe('notificationsSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [snap.snapId]: {
                 version: '1.0.0',
               },
@@ -237,7 +237,7 @@ describe('notificationsSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({}),
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({}),
           },
         },
       });

--- a/src/features/snap/components/Authorship.tsx
+++ b/src/features/snap/components/Authorship.tsx
@@ -3,12 +3,12 @@ import type { FunctionComponent } from 'react';
 
 import { SnapAvatar } from '../../../components';
 import type { Fields } from '../../../utils';
-import { useGetInstalledSnapsQuery } from '../../snaps';
+import { useGetAllInstalledSnapsQuery } from '../../snaps';
 
 export const Authorship: FunctionComponent<
   Fields<Queries.Snap, 'name' | 'snapId' | 'icon'>
 > = ({ name, snapId, icon }) => {
-  const { data: installedSnaps } = useGetInstalledSnapsQuery();
+  const { data: installedSnaps } = useGetAllInstalledSnapsQuery();
   const isInstalled = Boolean(installedSnaps?.[snapId]);
 
   return (

--- a/src/features/snaps/api.ts
+++ b/src/features/snaps/api.ts
@@ -1,3 +1,4 @@
+import { WALLET_SNAP_PERMISSION_KEY } from '@metamask/snaps-utils';
 import { createSelector } from '@reduxjs/toolkit';
 import { createApi } from '@reduxjs/toolkit/query/react';
 
@@ -30,11 +31,22 @@ export const snapsApi = createApi({
       }),
     }),
 
-    getInstalledSnaps: builder.query<InstalledSnaps, void>({
+    getAllInstalledSnaps: builder.query<InstalledSnaps, void>({
       query: () => ({
-        method: 'wallet_getSnaps',
+        method: 'wallet_getAllSnaps',
       }),
       providesTags: [SnapsTag.InstalledSnaps],
+    }),
+
+    revokePermissions: builder.mutation<null, void>({
+      query: () => ({
+        method: 'wallet_revokePermissions',
+        params: [
+          {
+            [WALLET_SNAP_PERMISSION_KEY]: {},
+          },
+        ],
+      }),
     }),
 
     installSnap: builder.mutation<InstallSnapResult, InstallSnapArgs>({
@@ -46,7 +58,7 @@ export const snapsApi = createApi({
           },
         },
       }),
-      onQueryStarted({ snapId, version }, api) {
+      async onQueryStarted({ snapId, version }, api) {
         const state = api.getState() as ApplicationState;
         const isUpdate = getUpdateAvailable(snapId)(state);
 
@@ -120,17 +132,18 @@ export const snapsApi = createApi({
 
 export const {
   useGetVersionQuery,
-  useGetInstalledSnapsQuery,
+  useGetAllInstalledSnapsQuery,
   useInstallSnapMutation,
+  useRevokePermissionsMutation,
 } = snapsApi;
 
-export const getInstalledSnaps = createSelector(
+export const getAllInstalledSnaps = createSelector(
   (state: ApplicationState) => state,
-  (state) => snapsApi.endpoints.getInstalledSnaps.select()(state).data ?? {},
+  (state) => snapsApi.endpoints.getAllInstalledSnaps.select()(state).data ?? {},
 );
 
 export const getInstalledSnap = (snapId: string) =>
   createSelector(
-    (state: ApplicationState) => getInstalledSnaps(state),
+    (state: ApplicationState) => getAllInstalledSnaps(state),
     (state) => state[snapId] ?? null,
   );

--- a/src/features/snaps/api.ts
+++ b/src/features/snaps/api.ts
@@ -58,7 +58,7 @@ export const snapsApi = createApi({
           },
         },
       }),
-      async onQueryStarted({ snapId, version }, api) {
+      onQueryStarted({ snapId, version }, api) {
         const state = api.getState() as ApplicationState;
         const isUpdate = getUpdateAvailable(snapId)(state);
 

--- a/src/features/snaps/components/SnapCard.tsx
+++ b/src/features/snaps/components/SnapCard.tsx
@@ -6,7 +6,7 @@ import type { FunctionComponent } from 'react';
 import { SnapCardImage } from './SnapCardImage';
 import { Card, SnapAvatar } from '../../../components';
 import type { Fields } from '../../../utils';
-import { useGetInstalledSnapsQuery } from '../api';
+import { useGetAllInstalledSnapsQuery } from '../api';
 
 export type SnapCardProps = Fields<
   Queries.Snap,
@@ -25,7 +25,7 @@ export const SnapCard: FunctionComponent<SnapCardProps> = ({
   image,
   onClick = () => undefined,
 }) => {
-  const { data: installedSnaps } = useGetInstalledSnapsQuery();
+  const { data: installedSnaps } = useGetAllInstalledSnapsQuery();
   const isInstalled = Boolean(installedSnaps?.[snapId]);
 
   return (

--- a/src/features/snaps/store.test.ts
+++ b/src/features/snaps/store.test.ts
@@ -45,7 +45,7 @@ describe('snapsSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({}),
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({}),
           },
         },
       });
@@ -60,7 +60,7 @@ describe('snapsSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               'snap-id': {
                 version: '1.0.0',
               },
@@ -80,7 +80,7 @@ describe('snapsSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [snap.snapId]: {
                 version: snap.latestVersion,
               },
@@ -100,7 +100,7 @@ describe('snapsSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [snap.snapId]: {
                 version: '1.1.0',
               },
@@ -120,7 +120,7 @@ describe('snapsSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [snap.snapId]: {
                 version: '1.0.0',
               },
@@ -144,7 +144,7 @@ describe('snapsSlice', () => {
         },
         snapsApi: {
           queries: {
-            'getInstalledSnaps(undefined)': getMockQueryResponse({
+            'getAllInstalledSnaps(undefined)': getMockQueryResponse({
               [barSnap.snapId]: {
                 version: '0.1.0',
               },

--- a/src/features/snaps/store.ts
+++ b/src/features/snaps/store.ts
@@ -2,7 +2,7 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSelector, createSlice } from '@reduxjs/toolkit';
 import semver from 'semver/preload';
 
-import { getInstalledSnaps } from './api';
+import { getAllInstalledSnaps } from './api';
 import type { RegistrySnapCategory } from '../../constants';
 import type { ApplicationState } from '../../store';
 import type { Fields } from '../../utils';
@@ -108,7 +108,7 @@ export const getSnapsById = (snapIds: string[]) => {
 export const getUpdateAvailable = (snapId: string) =>
   createSelector(
     (state: ApplicationState) => ({
-      installedSnaps: getInstalledSnaps(state),
+      installedSnaps: getAllInstalledSnaps(state),
       snaps: getSnaps(state),
     }),
     ({ installedSnaps, snaps }) => {
@@ -128,7 +128,7 @@ export const getUpdateAvailable = (snapId: string) =>
 
 export const getUpdatableSnaps = createSelector(
   (state: ApplicationState) => ({
-    snapIds: Object.keys(getInstalledSnaps(state)).filter((snapId) =>
+    snapIds: Object.keys(getAllInstalledSnaps(state)).filter((snapId) =>
       getUpdateAvailable(snapId)(state),
     ),
     snaps: getSnaps(state),

--- a/src/hooks/useSupportedVersion.test.ts
+++ b/src/hooks/useSupportedVersion.test.ts
@@ -14,7 +14,7 @@ describe('useSupportedVersion', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: new Error('Unsupported method.'),
+        wallet_getAllSnaps: new Error('Unsupported method.'),
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),
@@ -29,7 +29,7 @@ describe('useSupportedVersion', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: {},
+        wallet_getAllSnaps: {},
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),

--- a/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
+++ b/src/pages/snap/{Snap.location}/{Snap.slug}.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../components';
 import { RegistrySnapCategory } from '../../../constants';
 import {
-  useGetInstalledSnapsQuery,
+  useGetAllInstalledSnapsQuery,
   Authorship,
   RelatedSnaps,
   Metadata,
@@ -95,7 +95,7 @@ const SnapPage: FunctionComponent<SnapPageProps> = ({ data, pageContext }) => {
     installs,
   } = data.snap;
 
-  const { data: installedSnaps } = useGetInstalledSnapsQuery();
+  const { data: installedSnaps } = useGetAllInstalledSnapsQuery();
   const isInstalled = Boolean(installedSnaps?.[snapId]);
 
   return (

--- a/src/store/api.test.ts
+++ b/src/store/api.test.ts
@@ -49,7 +49,7 @@ describe('request', () => {
   it('calls the Snaps provider with the given method and params', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getSnaps: {},
+      wallet_getAllSnaps: {},
       foo: 'bar',
     });
 
@@ -70,7 +70,7 @@ describe('request', () => {
   it('returns an error if the provider throws', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getSnaps: {},
+      wallet_getAllSnaps: {},
       foo: new Error('Unsupported method.'),
     });
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -38,7 +38,7 @@ export function createStore(
   // home page.
   store
     .dispatch(
-      snapsApi.endpoints.getInstalledSnaps.initiate(undefined, {
+      snapsApi.endpoints.getAllInstalledSnaps.initiate(undefined, {
         forceRefetch: true,
       }),
     )

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -43,7 +43,7 @@ describe('hasSnapsSupport', () => {
   it('returns `true` if the provider supports Snaps', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getSnaps: {},
+      wallet_getAllSnaps: {},
     });
 
     expect(await hasSnapsSupport(provider)).toBe(true);
@@ -52,7 +52,7 @@ describe('hasSnapsSupport', () => {
   it('returns `false` if the provider does not support Snaps', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getSnaps: new Error('Unsupported method.'),
+      wallet_getAllSnaps: new Error('Unsupported method.'),
     });
 
     expect(await hasSnapsSupport(provider)).toBe(false);
@@ -228,7 +228,7 @@ describe('getSnapsProvider', () => {
       value: {
         ethereum: getRequestMethodMock({
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          wallet_getSnaps: {},
+          wallet_getAllSnaps: {},
         }),
       },
     });
@@ -239,7 +239,7 @@ describe('getSnapsProvider', () => {
   it('returns the provider if it is in the `window.ethereum.detected` array', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getSnaps: {},
+      wallet_getAllSnaps: {},
     });
 
     Object.defineProperty(globalThis, 'window', {
@@ -249,7 +249,7 @@ describe('getSnapsProvider', () => {
           detected: [
             getRequestMethodMock({
               // eslint-disable-next-line @typescript-eslint/naming-convention
-              wallet_getSnaps: new Error('Unsupported method.'),
+              wallet_getAllSnaps: new Error('Unsupported method.'),
             }),
             provider,
           ],
@@ -263,7 +263,7 @@ describe('getSnapsProvider', () => {
   it('returns the provider if it is in the `window.ethereum.providers` array', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getSnaps: {},
+      wallet_getAllSnaps: {},
     });
 
     Object.defineProperty(globalThis, 'window', {
@@ -273,7 +273,7 @@ describe('getSnapsProvider', () => {
           providers: [
             getRequestMethodMock({
               // eslint-disable-next-line @typescript-eslint/naming-convention
-              wallet_getSnaps: new Error('Unsupported method.'),
+              wallet_getAllSnaps: new Error('Unsupported method.'),
             }),
             provider,
           ],

--- a/src/utils/snaps.ts
+++ b/src/utils/snaps.ts
@@ -19,7 +19,7 @@ export type Fields<Query, Name extends keyof Query> = {
 };
 
 /**
- * Check if the current provider supports snaps by calling `wallet_getSnaps`.
+ * Check if the current provider supports snaps by calling `wallet_getAllSnaps`.
  *
  * @param provider - The provider to use to check for snaps support. Defaults to
  * `window.ethereum`.
@@ -30,7 +30,7 @@ export async function hasSnapsSupport(
 ) {
   try {
     await provider.request({
-      method: 'wallet_getSnaps',
+      method: 'wallet_getAllSnaps',
     });
 
     return true;


### PR DESCRIPTION
Closes [#1896](https://github.com/MetaMask/MetaMask-planning/issues/1896)

Swapping out `wallet_getSnaps` for `wallet_getAllSnaps` so that the directory doesn't need permission to get a list of the currently installed snaps. `wallet_revokePermissions` is invoked to remove the directory's `wallet_snap` permission on every install.