### PR TITLE
fix: Handle actual response type for `wallet_getAllSnaps`

### DIFF
--- a/src/components/InstallSnapButton.test.tsx
+++ b/src/components/InstallSnapButton.test.tsx
@@ -16,7 +16,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: {},
+        wallet_getAllSnaps: [],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),
@@ -55,7 +55,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: {},
+        wallet_getAllSnaps: [],
         web3_clientVersion: 'MetaMask/v11.0.0',
         wallet_requestSnaps: {
           [snap.snapId]: {
@@ -91,7 +91,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: {},
+        wallet_getAllSnaps: [],
         web3_clientVersion: 'MetaMask/v11.0.0',
         wallet_requestSnaps: new Error('User rejected the request.'),
         /* eslint-enable @typescript-eslint/naming-convention */
@@ -123,12 +123,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: {
-          [snap.snapId]: {
-            name: snap.name,
-            version: '0.1.0',
-          },
-        },
+        wallet_getAllSnaps: [{ id: snap.snapId, version: '0.1.0' }],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),
@@ -153,12 +148,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: {
-          [snap.snapId]: {
-            name: snap.name,
-            version: snap.latestVersion,
-          },
-        },
+        wallet_getAllSnaps: [{ id: snap.snapId, version: snap.latestVersion }],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),

--- a/src/features/notifications/components/NotificationAcknowledger.test.tsx
+++ b/src/features/notifications/components/NotificationAcknowledger.test.tsx
@@ -21,12 +21,7 @@ describe('NotificationAcknowledger', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: {
-          [snap.snapId]: {
-            name: snap.name,
-            version: '0.1.0',
-          },
-        },
+        wallet_getAllSnaps: [{ id: snap.snapId, version: '0.1.0' }],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),
@@ -58,12 +53,7 @@ describe('NotificationAcknowledger', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: {
-          [snap.snapId]: {
-            name: snap.name,
-            version: '0.1.0',
-          },
-        },
+        wallet_getAllSnaps: [{ id: snap.snapId, version: '0.1.0' }],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),
@@ -93,12 +83,7 @@ describe('NotificationAcknowledger', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: {
-          [snap.snapId]: {
-            name: snap.name,
-            version: '0.1.0',
-          },
-        },
+        wallet_getAllSnaps: [{ id: snap.snapId, version: '0.1.0' }],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),

--- a/src/features/notifications/components/NotificationsButton.test.tsx
+++ b/src/features/notifications/components/NotificationsButton.test.tsx
@@ -23,12 +23,7 @@ describe('NotificationsButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: {
-          [snap.snapId]: {
-            name: snap.name,
-            version: '0.1.0',
-          },
-        },
+        wallet_getAllSnaps: [{ id: snap.snapId, version: '0.1.0' }],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),

--- a/src/features/notifications/components/NotificationsList.test.tsx
+++ b/src/features/notifications/components/NotificationsList.test.tsx
@@ -18,20 +18,11 @@ describe('NotificationsList', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: {
-          [fooSnap.snapId]: {
-            name: fooSnap.name,
-            version: '0.1.0',
-          },
-          [barSnap.snapId]: {
-            name: barSnap.name,
-            version: '0.1.0',
-          },
-          [bazSnap.snapId]: {
-            name: bazSnap.name,
-            version: '0.1.0',
-          },
-        },
+        wallet_getAllSnaps: [
+          { id: fooSnap.snapId, version: '0.1.0' },
+          { id: barSnap.snapId, version: '0.1.0' },
+          { id: bazSnap.snapId, version: '0.1.0' },
+        ],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),

--- a/src/features/snaps/api.test.ts
+++ b/src/features/snaps/api.test.ts
@@ -71,11 +71,9 @@ describe('snapsApi', () => {
       Object.assign(globalThis, 'window', {
         ethereum: getRequestMethodMock({
           /* eslint-disable @typescript-eslint/naming-convention */
-          wallet_getAllSnaps: {
-            [snap.snapId]: {
-              version: snap.latestVersion,
-            },
-          },
+          wallet_getAllSnaps: [
+            { id: snap.snapId, version: snap.latestVersion },
+          ],
           /* eslint-enable @typescript-eslint/naming-convention */
         }),
       });
@@ -86,6 +84,7 @@ describe('snapsApi', () => {
 
       expect(result.current.data).toStrictEqual({
         [snap.snapId]: {
+          id: snap.snapId,
           version: snap.latestVersion,
         },
       });
@@ -353,11 +352,7 @@ describe('snapsApi', () => {
       Object.assign(globalThis, 'window', {
         ethereum: getRequestMethodMock({
           /* eslint-disable @typescript-eslint/naming-convention */
-          wallet_getAllSnaps: {
-            [snap.snapId]: {
-              version: '1.0.0',
-            },
-          },
+          wallet_getAllSnaps: [{ id: snap.snapId, version: '1.0.0' }],
           wallet_requestSnaps: {
             [snap.snapId]: {
               error: null,

--- a/src/features/snaps/api.ts
+++ b/src/features/snaps/api.ts
@@ -19,6 +19,7 @@ export type InstallSnapArgs = {
 
 export type InstalledSnaps = Record<string, { version: string }>;
 export type InstallSnapResult = Record<string, { error: unknown }>;
+export type GetAllSnapsResult = { id: string; version: string }[];
 
 export const snapsApi = createApi({
   reducerPath: 'snapsApi',
@@ -35,6 +36,15 @@ export const snapsApi = createApi({
       query: () => ({
         method: 'wallet_getAllSnaps',
       }),
+      transformResponse(snaps: GetAllSnapsResult) {
+        return snaps.reduce<Record<string, GetAllSnapsResult[0]>>(
+          (accumulator, snap) => {
+            accumulator[snap.id] = snap;
+            return accumulator;
+          },
+          {},
+        );
+      },
       providesTags: [SnapsTag.InstalledSnaps],
     }),
 

--- a/src/hooks/useSupportedVersion.test.ts
+++ b/src/hooks/useSupportedVersion.test.ts
@@ -29,7 +29,7 @@ describe('useSupportedVersion', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: {},
+        wallet_getAllSnaps: [],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -43,7 +43,7 @@ describe('hasSnapsSupport', () => {
   it('returns `true` if the provider supports Snaps', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getAllSnaps: {},
+      wallet_getAllSnaps: [],
     });
 
     expect(await hasSnapsSupport(provider)).toBe(true);
@@ -228,7 +228,7 @@ describe('getSnapsProvider', () => {
       value: {
         ethereum: getRequestMethodMock({
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          wallet_getAllSnaps: {},
+          wallet_getAllSnaps: [],
         }),
       },
     });
@@ -239,7 +239,7 @@ describe('getSnapsProvider', () => {
   it('returns the provider if it is in the `window.ethereum.detected` array', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getAllSnaps: {},
+      wallet_getAllSnaps: [],
     });
 
     Object.defineProperty(globalThis, 'window', {
@@ -263,7 +263,7 @@ describe('getSnapsProvider', () => {
   it('returns the provider if it is in the `window.ethereum.providers` array', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getAllSnaps: {},
+      wallet_getAllSnaps: [],
     });
 
     Object.defineProperty(globalThis, 'window', {


### PR DESCRIPTION
Detecting of installed Snaps is currently broken due to a mismatch in expectation of the return value for `wallet_getAllSnaps`. The RPC method currently returns an array while the site expects an object. This PR fixes this by transforming the array to an object once received.