### PR TITLE
Fix build errors

### DIFF
--- a/src/features/snaps/api.ts
+++ b/src/features/snaps/api.ts
@@ -37,7 +37,11 @@ export const snapsApi = createApi({
         method: 'wallet_getAllSnaps',
       }),
       transformResponse(snaps: GetAllSnapsResult) {
-        return snaps.reduce<Record<string, GetAllSnapsResult[0]>>(
+        if (!snaps) {
+          return {};
+        }
+
+        return snaps?.reduce<Record<string, GetAllSnapsResult[0]>>(
           (accumulator, snap) => {
             accumulator[snap.id] = snap;
             return accumulator;

--- a/src/features/snaps/api.ts
+++ b/src/features/snaps/api.ts
@@ -41,7 +41,7 @@ export const snapsApi = createApi({
           return {};
         }
 
-        return snaps?.reduce<Record<string, GetAllSnapsResult[0]>>(
+        return snaps.reduce<Record<string, GetAllSnapsResult[0]>>(
           (accumulator, snap) => {
             accumulator[snap.id] = snap;
             return accumulator;


### PR DESCRIPTION
After #448, there were some build errors, at least in CI. This adds some validation to make sure `snaps` is defined before trying to process it.