### PR TITLE
Removed open beta messaging

### DIFF
--- a/src/components/InstallUnsupportedMobile.tsx
+++ b/src/components/InstallUnsupportedMobile.tsx
@@ -58,8 +58,8 @@ export const InstallUnsupportedMobile: FunctionComponent<
             </Heading>
             <Text color="text.alternative" textAlign="center" marginTop={4}>
               <Trans>
-                MetaMask Snaps is in open beta and only supported via our
-                extension clients on desktop such as{' '}
+                MetaMask Snaps are currently only supported via our extension
+                clients on desktop such as{' '}
                 <Link href="https://brave.com/" isExternal={true}>
                   Brave
                 </Link>

--- a/src/components/InstallUnsupportedMobile.tsx
+++ b/src/components/InstallUnsupportedMobile.tsx
@@ -58,7 +58,7 @@ export const InstallUnsupportedMobile: FunctionComponent<
             </Heading>
             <Text color="text.alternative" textAlign="center" marginTop={4}>
               <Trans>
-                MetaMask Snaps are currently only supported via our extension
+                MetaMask Snaps is currently only supported via our extension
                 clients on desktop such as{' '}
                 <Link href="https://brave.com/" isExternal={true}>
                   Brave

--- a/src/features/banner/components/explore-banner/ExploreBanner.test.tsx
+++ b/src/features/banner/components/explore-banner/ExploreBanner.test.tsx
@@ -5,7 +5,7 @@ describe('ExploreBanner', () => {
   it('renders the banner', () => {
     const { queryByText } = render(<ExploreBanner snaps={[]} />);
 
-    expect(queryByText('Live')).toBeInTheDocument();
+    expect(queryByText('Live in MetaMask')).toBeInTheDocument();
   });
 
   it('renders the Snaps', () => {

--- a/src/features/banner/components/explore-banner/ExploreBanner.test.tsx
+++ b/src/features/banner/components/explore-banner/ExploreBanner.test.tsx
@@ -5,7 +5,7 @@ describe('ExploreBanner', () => {
   it('renders the banner', () => {
     const { queryByText } = render(<ExploreBanner snaps={[]} />);
 
-    expect(queryByText('Everyone')).toBeInTheDocument();
+    expect(queryByText('Live')).toBeInTheDocument();
   });
 
   it('renders the Snaps', () => {

--- a/src/features/banner/components/explore-banner/ExploreBanner.test.tsx
+++ b/src/features/banner/components/explore-banner/ExploreBanner.test.tsx
@@ -5,7 +5,7 @@ describe('ExploreBanner', () => {
   it('renders the banner', () => {
     const { queryByText } = render(<ExploreBanner snaps={[]} />);
 
-    expect(queryByText('Open Beta Live')).toBeInTheDocument();
+    expect(queryByText('Everyone')).toBeInTheDocument();
   });
 
   it('renders the Snaps', () => {

--- a/src/features/banner/components/explore-banner/ExploreBanner.tsx
+++ b/src/features/banner/components/explore-banner/ExploreBanner.tsx
@@ -28,7 +28,7 @@ export const ExploreBanner: FunctionComponent<ExploreBannerProps> = ({
     }}
   >
     <Announcement>
-      <Trans>Open Beta Live</Trans>
+      <Trans>Everyone</Trans>
     </Announcement>
     <Heading
       fontSize={['3xl', '4xl', '5xl']}

--- a/src/features/banner/components/explore-banner/ExploreBanner.tsx
+++ b/src/features/banner/components/explore-banner/ExploreBanner.tsx
@@ -28,7 +28,7 @@ export const ExploreBanner: FunctionComponent<ExploreBannerProps> = ({
     }}
   >
     <Announcement>
-      <Trans>Live</Trans>
+      <Trans>Live in MetaMask</Trans>
     </Announcement>
     <Heading
       fontSize={['3xl', '4xl', '5xl']}

--- a/src/features/banner/components/explore-banner/ExploreBanner.tsx
+++ b/src/features/banner/components/explore-banner/ExploreBanner.tsx
@@ -28,7 +28,7 @@ export const ExploreBanner: FunctionComponent<ExploreBannerProps> = ({
     }}
   >
     <Announcement>
-      <Trans>Everyone</Trans>
+      <Trans>Live</Trans>
     </Announcement>
     <Heading
       fontSize={['3xl', '4xl', '5xl']}

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -573,7 +573,7 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgid "MetaMask Snaps is currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
 #: src/features/filter/constants.tsx

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -348,10 +348,6 @@ msgstr "Lichtmodus aktivieren"
 msgid "Ethereum"
 msgstr "Ethereum"
 
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Everyone"
-msgstr ""
-
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "Experimentelle Beta"
@@ -544,6 +540,7 @@ msgid "Link"
 msgstr "Link"
 
 #: src/components/icons/index.ts
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "Live"
 

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -348,6 +348,10 @@ msgstr "Lichtmodus aktivieren"
 msgid "Ethereum"
 msgstr "Ethereum"
 
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Everyone"
+msgstr ""
+
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "Experimentelle Beta"
@@ -569,8 +573,8 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
-msgstr "MetaMask Snaps befindet sich in der Open Beta und wird nur über unsere Erweiterungsclients auf dem Desktop wie <0>Brave</0>, <1>Chrome</1> oder <2>Firefox</2> unterstützt."
+msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgstr ""
 
 #: src/features/filter/constants.tsx
 #: src/pages/index.tsx
@@ -601,10 +605,6 @@ msgstr "Benachrichtigungen und Chat"
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 msgid "Open"
 msgstr "Öffnen"
-
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Open Beta Live"
-msgstr "Beta Live öffnen"
 
 #: src/features/filter/components/FilterButton.tsx
 msgid "Open filter menu"

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -540,9 +540,12 @@ msgid "Link"
 msgstr "Link"
 
 #: src/components/icons/index.ts
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "Live"
+
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Live in MetaMask"
+msgstr ""
 
 #: src/features/snap/permissions.tsx
 #: src/features/snap/permissions.tsx

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -343,6 +343,10 @@ msgstr ""
 msgid "Ethereum"
 msgstr ""
 
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Everyone"
+msgstr "Everyone"
+
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr ""
@@ -564,8 +568,8 @@ msgid "MetaMask"
 msgstr ""
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
-msgstr ""
+msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgstr "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 
 #: src/features/filter/constants.tsx
 #: src/pages/index.tsx
@@ -595,10 +599,6 @@ msgstr ""
 #: src/components/SnapWebsiteButton.tsx
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 msgid "Open"
-msgstr ""
-
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Open Beta Live"
 msgstr ""
 
 #: src/features/filter/components/FilterButton.tsx

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -343,10 +343,6 @@ msgstr ""
 msgid "Ethereum"
 msgstr ""
 
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Everyone"
-msgstr "Everyone"
-
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr ""
@@ -539,6 +535,7 @@ msgid "Link"
 msgstr ""
 
 #: src/components/icons/index.ts
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr ""
 

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -535,9 +535,12 @@ msgid "Link"
 msgstr ""
 
 #: src/components/icons/index.ts
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr ""
+
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Live in MetaMask"
+msgstr "Live in MetaMask"
 
 #: src/features/snap/permissions.tsx
 #: src/features/snap/permissions.tsx

--- a/src/locales/en-US/messages.po
+++ b/src/locales/en-US/messages.po
@@ -568,8 +568,8 @@ msgid "MetaMask"
 msgstr ""
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
-msgstr "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgid "MetaMask Snaps is currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgstr "MetaMask Snaps is currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 
 #: src/features/filter/constants.tsx
 #: src/pages/index.tsx

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -573,7 +573,7 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgid "MetaMask Snaps is currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
 #: src/features/filter/constants.tsx

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -348,10 +348,6 @@ msgstr "ライトモードを有効にする"
 msgid "Ethereum"
 msgstr "イーサリアム"
 
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Everyone"
-msgstr ""
-
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "試験運用ベータ版"
@@ -544,6 +540,7 @@ msgid "Link"
 msgstr "リンク"
 
 #: src/components/icons/index.ts
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "ライブ"
 

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -348,6 +348,10 @@ msgstr "ライトモードを有効にする"
 msgid "Ethereum"
 msgstr "イーサリアム"
 
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Everyone"
+msgstr ""
+
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "試験運用ベータ版"
@@ -569,8 +573,8 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
-msgstr "MetaMask Snapはオープンベータで、<0>Brave</0>、<1>Chrome</1>、<2>Firefox</2>などのデスクトップ版の拡張機能クライアントでのみサポートされています。"
+msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgstr ""
 
 #: src/features/filter/constants.tsx
 #: src/pages/index.tsx
@@ -601,10 +605,6 @@ msgstr "通知とチャット"
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 msgid "Open"
 msgstr "開く"
-
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Open Beta Live"
-msgstr "オープンベータライブ"
 
 #: src/features/filter/components/FilterButton.tsx
 msgid "Open filter menu"

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -540,9 +540,12 @@ msgid "Link"
 msgstr "リンク"
 
 #: src/components/icons/index.ts
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "ライブ"
+
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Live in MetaMask"
+msgstr ""
 
 #: src/features/snap/permissions.tsx
 #: src/features/snap/permissions.tsx

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -573,7 +573,7 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgid "MetaMask Snaps is currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
 #: src/features/filter/constants.tsx

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -540,9 +540,12 @@ msgid "Link"
 msgstr "Link"
 
 #: src/components/icons/index.ts
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "No ar"
+
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Live in MetaMask"
+msgstr ""
 
 #: src/features/snap/permissions.tsx
 #: src/features/snap/permissions.tsx

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -348,10 +348,6 @@ msgstr "Ativar modo claro"
 msgid "Ethereum"
 msgstr "Ethereum"
 
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Everyone"
-msgstr ""
-
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "Beta experimental"
@@ -544,6 +540,7 @@ msgid "Link"
 msgstr "Link"
 
 #: src/components/icons/index.ts
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "No ar"
 

--- a/src/locales/pt-BR/messages.po
+++ b/src/locales/pt-BR/messages.po
@@ -348,6 +348,10 @@ msgstr "Ativar modo claro"
 msgid "Ethereum"
 msgstr "Ethereum"
 
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Everyone"
+msgstr ""
+
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "Beta experimental"
@@ -569,8 +573,8 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
-msgstr "O MetaMask Snaps está em beta aberto e só é compatível através dos nossos clientes da extensão para desktop como <0>Brave</0>, <1>Chrome</1> ou <2>Firefox</2>."
+msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgstr ""
 
 #: src/features/filter/constants.tsx
 #: src/pages/index.tsx
@@ -601,10 +605,6 @@ msgstr "Notificações e chat"
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 msgid "Open"
 msgstr "Abrir"
-
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Open Beta Live"
-msgstr "Beta aberto no ar"
 
 #: src/features/filter/components/FilterButton.tsx
 msgid "Open filter menu"

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -348,6 +348,10 @@ msgstr "Включить светлый режим"
 msgid "Ethereum"
 msgstr "Ethereum"
 
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Everyone"
+msgstr ""
+
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "Экспериментальная бета-версия"
@@ -569,8 +573,8 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
-msgstr "MetaMask Snaps находится на стадии открытой бета-версии и поддерживается только через наши клиенты расширений для браузеров персональных компьютеров, таких как <0>Brave</0>, <1>Chrome</1> и <2>Firefox</2>."
+msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgstr ""
 
 #: src/features/filter/constants.tsx
 #: src/pages/index.tsx
@@ -601,10 +605,6 @@ msgstr "Уведомления и чат"
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 msgid "Open"
 msgstr "Открыть"
-
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Open Beta Live"
-msgstr "Открыть выпущенную бета-версию"
 
 #: src/features/filter/components/FilterButton.tsx
 msgid "Open filter menu"

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -573,7 +573,7 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgid "MetaMask Snaps is currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
 #: src/features/filter/constants.tsx

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -540,9 +540,12 @@ msgid "Link"
 msgstr "Ссылка"
 
 #: src/components/icons/index.ts
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "Выпущенная версия"
+
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Live in MetaMask"
+msgstr ""
 
 #: src/features/snap/permissions.tsx
 #: src/features/snap/permissions.tsx

--- a/src/locales/ru-RU/messages.po
+++ b/src/locales/ru-RU/messages.po
@@ -348,10 +348,6 @@ msgstr "Включить светлый режим"
 msgid "Ethereum"
 msgstr "Ethereum"
 
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Everyone"
-msgstr ""
-
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "Экспериментальная бета-версия"
@@ -544,6 +540,7 @@ msgid "Link"
 msgstr "Ссылка"
 
 #: src/components/icons/index.ts
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "Выпущенная версия"
 

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -573,7 +573,7 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgid "MetaMask Snaps is currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
 #: src/features/filter/constants.tsx

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -348,10 +348,6 @@ msgstr "Aydınlık modu etkinleştir"
 msgid "Ethereum"
 msgstr "Ethereum"
 
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Everyone"
-msgstr ""
-
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "Deneysel Beta"
@@ -544,6 +540,7 @@ msgid "Link"
 msgstr "Bağlantı"
 
 #: src/components/icons/index.ts
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "Canlı"
 

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -540,9 +540,12 @@ msgid "Link"
 msgstr "Bağlantı"
 
 #: src/components/icons/index.ts
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "Canlı"
+
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Live in MetaMask"
+msgstr ""
 
 #: src/features/snap/permissions.tsx
 #: src/features/snap/permissions.tsx

--- a/src/locales/tr-TR/messages.po
+++ b/src/locales/tr-TR/messages.po
@@ -348,6 +348,10 @@ msgstr "Aydınlık modu etkinleştir"
 msgid "Ethereum"
 msgstr "Ethereum"
 
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Everyone"
+msgstr ""
+
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "Deneysel Beta"
@@ -569,8 +573,8 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
-msgstr "MetaMask Snaps, açık beta durumundadır ve sadece <0>Brave</0>, <1>Chrome</1> veya <2>Firefox</2> gibi masaüstünde uzantı istemcilerimiz ile desteklenir."
+msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgstr ""
 
 #: src/features/filter/constants.tsx
 #: src/pages/index.tsx
@@ -601,10 +605,6 @@ msgstr "Bildirimler ve Sohbet"
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 msgid "Open"
 msgstr "Aç"
-
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Open Beta Live"
-msgstr "Beta Live'i Aç"
 
 #: src/features/filter/components/FilterButton.tsx
 msgid "Open filter menu"

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -573,7 +573,7 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgid "MetaMask Snaps is currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
 msgstr ""
 
 #: src/features/filter/constants.tsx

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -348,10 +348,6 @@ msgstr "启用浅色模式"
 msgid "Ethereum"
 msgstr "以太坊"
 
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Everyone"
-msgstr ""
-
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "实验性测试版"
@@ -544,6 +540,7 @@ msgid "Link"
 msgstr "链接"
 
 #: src/components/icons/index.ts
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "在线"
 

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -540,9 +540,12 @@ msgid "Link"
 msgstr "链接"
 
 #: src/components/icons/index.ts
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
 msgid "Live"
 msgstr "在线"
+
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Live in MetaMask"
+msgstr ""
 
 #: src/features/snap/permissions.tsx
 #: src/features/snap/permissions.tsx

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -348,6 +348,10 @@ msgstr "启用浅色模式"
 msgid "Ethereum"
 msgstr "以太坊"
 
+#: src/features/banner/components/explore-banner/ExploreBanner.tsx
+msgid "Everyone"
+msgstr ""
+
 #: src/components/FooterAccountManagementTerms.tsx
 msgid "Experimental Beta"
 msgstr "实验性测试版"
@@ -569,8 +573,8 @@ msgid "MetaMask"
 msgstr "MetaMask"
 
 #: src/components/InstallUnsupportedMobile.tsx
-msgid "MetaMask Snaps is in open beta and only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
-msgstr "MetaMask Snaps 目前处于公测阶段，仅通过 <0>Brave</0>、<1>Chrome</1> 或 <2>Firefox</2> 等桌面上的扩展客户端获得支持。"
+msgid "MetaMask Snaps are currently only supported via our extension clients on desktop such as <0>Brave</0>, <1>Chrome</1>, or <2>Firefox</2>."
+msgstr ""
 
 #: src/features/filter/constants.tsx
 #: src/pages/index.tsx
@@ -601,10 +605,6 @@ msgstr "通知和聊天"
 #: src/features/banner/components/faq-banner/FaqBanner.tsx
 msgid "Open"
 msgstr "打开"
-
-#: src/features/banner/components/explore-banner/ExploreBanner.tsx
-msgid "Open Beta Live"
-msgstr "打开在线测试版"
 
 #: src/features/filter/components/FilterButton.tsx
 msgid "Open filter menu"


### PR DESCRIPTION
Snaps are no longer an open beta and thus the messaging has been removed

fixes https://github.com/MetaMask/MetaMask-planning/issues/2963