### PR TITLE
Use `metamask-snaps-deployments` channel for deployment messages

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ on:
       slack-channel:
         required: false
         type: string
-        default: 'metamask-snaps'
+        default: 'metamask-snaps-deployments'
       slack-icon-url:
         required: false
         type: string

--- a/.github/workflows/republish-release.yml
+++ b/.github/workflows/republish-release.yml
@@ -7,7 +7,7 @@ on:
         required: false
         type: string
         description: 'The Slack channel to post to.'
-        default: 'metamask-snaps'
+        default: 'metamask-snaps-deployments'
       slack-icon-url:
         required: false
         type: string


### PR DESCRIPTION
This updates the publish workflows to send a Slack message in `metamask-snaps-deployments`.