### PR TITLE
Update MM Support links to paths current as of January 9, 2025

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -21,7 +21,7 @@ export const Banner: FunctionComponent = () => (
           </Link>{' '}
           and{' '}
           <Link
-            href="https://support.metamask.io/hc/en-us/articles/18245938714395"
+            href="https://support.metamask.io/configure/snaps/metamask-snaps-faq/"
             isExternal={true}
           >
             FAQ

--- a/src/components/FooterLinks.tsx
+++ b/src/components/FooterLinks.tsx
@@ -22,7 +22,7 @@ export const FOOTER_LINKS = [
     links: [
       {
         title: defineMessage`Contact Us`,
-        url: 'https://support.metamask.io/hc/en-us/articles/360058969391-How-to-contact-MetaMask-Support',
+        url: 'https://support.metamask.io/start/how-to-contact-metamask-support/',
       },
       {
         title: defineMessage`Feedback`,

--- a/src/components/InstallUnsupportedDesktopUpdate.tsx
+++ b/src/components/InstallUnsupportedDesktopUpdate.tsx
@@ -18,7 +18,7 @@ export const InstallUnsupportedDesktopUpdate: FunctionComponent<
         To use MetaMask Snaps, you need the latest version (11.0) of MetaMask in
         your browser.{' '}
         <Link
-          href="https://support.metamask.io/hc/en-us/articles/360060268452-How-to-update-the-version-of-MetaMask"
+          href="https://support.metamask.io/configure/wallet/how-to-update-the-version-of-metamask/"
           isExternal={true}
         >
           Learn more.

--- a/src/features/banner/components/faq-banner/FaqBanner.tsx
+++ b/src/features/banner/components/faq-banner/FaqBanner.tsx
@@ -9,7 +9,7 @@ import { Base } from '../Base';
 
 export const FaqBanner: FunctionComponent = () => (
   <Base
-    to="https://support.metamask.io/hc/en-us/articles/18245938714395"
+    to="https://support.metamask.io/configure/snaps/metamask-snaps-faq/"
     external={true}
     // Based on `error.muted`, but without opacity.
     background="#efd7d7"


### PR DESCRIPTION
This PR updates links to `support.metamask.io` that are, at this point, ~9 months deprecated.

Maintaining the redirects is getting impossible.

These paths should be redirected to, in the future, in case of any further changes; we also intend to make an internal npm package to serve as a single source of truth for MM website resources in product.

Solves [this bug](https://github.com/MetaMask/metamask-extension/issues/29644), along with [this](https://github.com/Consensys/docs-mm-helpcenter/pull/590). 