### PR TITLE
fix: Correct ordering for search results

### DIFF
--- a/src/features/snaps/store.test.ts
+++ b/src/features/snaps/store.test.ts
@@ -1,5 +1,6 @@
 import {
   getSnaps,
+  getSnapsById,
   getUpdatableSnaps,
   getUpdateAvailable,
   setSnaps,
@@ -34,6 +35,26 @@ describe('snapsSlice', () => {
       });
 
       expect(getSnaps(state)).toStrictEqual([getMockSnap().snap]);
+    });
+  });
+
+  describe('getSnapsById', () => {
+    it('returns the filtered snaps in the requested order', () => {
+      const mockSnaps = [
+        getMockSnap({ snapId: 'npm:snap1' }).snap,
+        getMockSnap({ snapId: 'npm:snap2' }).snap,
+        getMockSnap({ snapId: 'npm:snap3' }).snap,
+      ];
+      const state = getMockState({
+        snaps: {
+          snaps: mockSnaps,
+        },
+      });
+
+      expect(getSnapsById(['npm:snap3', 'npm:snap2'])(state)).toStrictEqual([
+        mockSnaps[2],
+        mockSnaps[1],
+      ]);
     });
   });
 

--- a/src/features/snaps/store.ts
+++ b/src/features/snaps/store.ts
@@ -100,7 +100,10 @@ export const getSnapsById = (snapIds: string[]) => {
         return [];
       }
 
-      return snaps.filter((snap) => snapIds.includes(snap.snapId));
+      // The ordering of the input may be important so we must return it in the same order.
+      return snapIds.map((snapId) =>
+        snaps.find((snap) => snap.snapId === snapId),
+      );
     },
   );
 };


### PR DESCRIPTION
This PR changes `getSnapsById` to ensure that it returns the Snaps requested in the same order that the input specifies. This is important because the input may already be sorted by relevance (e.g. for search). This fix should significantly improve search results. 