### PR TITLE
Add weights to search keys

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -75,7 +75,24 @@ const config: GatsbyConfig = {
             }
           }
         `,
-        keys: ['snapId', 'name', 'summary', 'description'],
+        keys: [
+          {
+            name: 'name',
+            weight: 3,
+          },
+          {
+            name: 'snapId',
+            weight: 2,
+          },
+          {
+            name: 'summary',
+            weight: 1,
+          },
+          {
+            name: 'description',
+            weight: 1,
+          },
+        ],
         normalizer: ({ data }) =>
           data.allSnap.nodes.map((node) => ({
             snapId: node.snapId,


### PR DESCRIPTION
This updates the search functionality to use weights. The Snap name is now the most important part used in the search, followed by the Snap ID, and lastly the summary and description.