### PR TITLE
Update provider detection to use `wallet_getSnaps`

### DIFF
--- a/src/components/InstallSnapButton.test.tsx
+++ b/src/components/InstallSnapButton.test.tsx
@@ -16,7 +16,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: [],
+        wallet_getSnaps: {},
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),
@@ -55,7 +55,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: [],
+        wallet_getSnaps: {},
         web3_clientVersion: 'MetaMask/v11.0.0',
         wallet_requestSnaps: {
           [snap.snapId]: {
@@ -91,7 +91,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: [],
+        wallet_getSnaps: {},
         web3_clientVersion: 'MetaMask/v11.0.0',
         wallet_requestSnaps: new Error('User rejected the request.'),
         /* eslint-enable @typescript-eslint/naming-convention */
@@ -123,7 +123,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: [],
+        wallet_getSnaps: {},
         wallet_getAllSnaps: [{ id: snap.snapId, version: '0.1.0' }],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
@@ -149,7 +149,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: [],
+        wallet_getSnaps: {},
         wallet_getAllSnaps: [{ id: snap.snapId, version: snap.latestVersion }],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */

--- a/src/components/InstallSnapButton.test.tsx
+++ b/src/components/InstallSnapButton.test.tsx
@@ -16,7 +16,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: [],
+        wallet_getSnaps: [],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),
@@ -35,7 +35,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: new Error('Snaps are not supported.'),
+        wallet_getSnaps: new Error('Snaps are not supported.'),
         web3_clientVersion: 'MetaMask/v10.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),
@@ -55,7 +55,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: [],
+        wallet_getSnaps: [],
         web3_clientVersion: 'MetaMask/v11.0.0',
         wallet_requestSnaps: {
           [snap.snapId]: {
@@ -91,7 +91,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: [],
+        wallet_getSnaps: [],
         web3_clientVersion: 'MetaMask/v11.0.0',
         wallet_requestSnaps: new Error('User rejected the request.'),
         /* eslint-enable @typescript-eslint/naming-convention */
@@ -123,6 +123,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
+        wallet_getSnaps: [],
         wallet_getAllSnaps: [{ id: snap.snapId, version: '0.1.0' }],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
@@ -148,6 +149,7 @@ describe('InstallSnapButton', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
+        wallet_getSnaps: [],
         wallet_getAllSnaps: [{ id: snap.snapId, version: snap.latestVersion }],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */

--- a/src/hooks/useSupportedVersion.test.ts
+++ b/src/hooks/useSupportedVersion.test.ts
@@ -29,7 +29,7 @@ describe('useSupportedVersion', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getSnaps: [],
+        wallet_getSnaps: {},
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),

--- a/src/hooks/useSupportedVersion.test.ts
+++ b/src/hooks/useSupportedVersion.test.ts
@@ -14,7 +14,7 @@ describe('useSupportedVersion', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: new Error('Unsupported method.'),
+        wallet_getSnaps: new Error('Unsupported method.'),
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),
@@ -29,7 +29,7 @@ describe('useSupportedVersion', () => {
     Object.assign(globalThis, 'window', {
       ethereum: getRequestMethodMock({
         /* eslint-disable @typescript-eslint/naming-convention */
-        wallet_getAllSnaps: [],
+        wallet_getSnaps: [],
         web3_clientVersion: 'MetaMask/v11.0.0',
         /* eslint-enable @typescript-eslint/naming-convention */
       }),

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -52,7 +52,7 @@ describe('hasSnapsSupport', () => {
   it('returns `false` if the provider does not support Snaps', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getAllSnaps: new Error('Unsupported method.'),
+      wallet_getSnaps: new Error('Unsupported method.'),
     });
 
     expect(await hasSnapsSupport(provider)).toBe(false);
@@ -249,7 +249,7 @@ describe('getSnapsProvider', () => {
           detected: [
             getRequestMethodMock({
               // eslint-disable-next-line @typescript-eslint/naming-convention
-              wallet_getAllSnaps: new Error('Unsupported method.'),
+              wallet_getSnaps: new Error('Unsupported method.'),
             }),
             provider,
           ],
@@ -263,7 +263,7 @@ describe('getSnapsProvider', () => {
   it('returns the provider if it is in the `window.ethereum.providers` array', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getAllSnaps: [],
+      wallet_getSnaps: [],
     });
 
     Object.defineProperty(globalThis, 'window', {
@@ -273,7 +273,7 @@ describe('getSnapsProvider', () => {
           providers: [
             getRequestMethodMock({
               // eslint-disable-next-line @typescript-eslint/naming-convention
-              wallet_getAllSnaps: new Error('Unsupported method.'),
+              wallet_getSnaps: new Error('Unsupported method.'),
             }),
             provider,
           ],

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -263,7 +263,7 @@ describe('getSnapsProvider', () => {
   it('returns the provider if it is in the `window.ethereum.providers` array', async () => {
     const provider = getRequestMethodMock({
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      wallet_getSnaps: [],
+      wallet_getSnaps: {},
     });
 
     Object.defineProperty(globalThis, 'window', {

--- a/src/utils/snaps.ts
+++ b/src/utils/snaps.ts
@@ -19,7 +19,7 @@ export type Fields<Query, Name extends keyof Query> = {
 };
 
 /**
- * Check if the current provider supports snaps by calling `wallet_getAllSnaps`.
+ * Check if the current provider supports snaps by calling `wallet_getSnaps`.
  *
  * @param provider - The provider to use to check for snaps support. Defaults to
  * `window.ethereum`.
@@ -30,7 +30,7 @@ export async function hasSnapsSupport(
 ) {
   try {
     await provider.request({
-      method: 'wallet_getAllSnaps',
+      method: 'wallet_getSnaps',
     });
 
     return true;


### PR DESCRIPTION
This change only affects staging. It replaces `wallet_getAllSnaps` with `wallet_getSnaps` when detecting the Ethereum provider (`window.ethereum`). `wallet_getAllSnaps` is allowlisted based on the origin, but the staging URL is not on this allowlist. We can use `wallet_getSnaps` to reliably detect if the provider supports Snaps though, and this works in the staging environment as well.