### PR TITLE
Adjust padding of search input

### DIFF
--- a/src/features/filter/components/FilterSearchInput.tsx
+++ b/src/features/filter/components/FilterSearchInput.tsx
@@ -35,7 +35,7 @@ export const FilterSearchInput: FunctionComponent<FilterSearchInputProps> =
 
     return (
       <InputGroup ref={ref}>
-        <InputLeftElement>
+        <InputLeftElement pointerEvents="none">
           <SearchFieldIcon />
         </InputLeftElement>
         <Input
@@ -46,6 +46,8 @@ export const FilterSearchInput: FunctionComponent<FilterSearchInputProps> =
           onChange={onFormChange}
           onClick={onFormClick}
           onKeyDown={handleKeyDown}
+          paddingX="4"
+          paddingY="2"
         />
       </InputGroup>
     );


### PR DESCRIPTION
This adjusts the padding of the search input, so that the clear icon isn't squished:

<img width="230" alt="image" src="https://github.com/user-attachments/assets/bfa7acc4-a825-44a0-9209-f348930a3118" />