### PR TITLE
feat: Prefer EIP-6963 for detecting providers

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -31,4 +31,32 @@ beforeEach(() => {
 
     originalConsoleError(error, ...args);
   });
+
+  const realAddEventListener = window?.addEventListener?.bind?.(window);
+
+  // Return window.ethereum for EIP6963 when applicable.
+  Object.assign(globalThis, 'window', {
+    addEventListener: jest.fn().mockImplementation((type, listener) => {
+      if (
+        typeof listener === 'function' &&
+        type === 'eip6963:announceProvider' &&
+        window.ethereum
+      ) {
+        listener(
+          new CustomEvent('eip6963:announceProvider', {
+            detail: {
+              info: {
+                name: 'MetaMask',
+                rdns: 'io.metamask',
+                uuid: '359b317d-0e02-4cea-ade8-7f671fdd5c7e',
+              },
+              provider: window.ethereum,
+            },
+          }),
+        );
+      } else {
+        realAddEventListener(type, listener);
+      }
+    }),
+  });
 });

--- a/src/store/api.test.ts
+++ b/src/store/api.test.ts
@@ -57,6 +57,9 @@ describe('request', () => {
       writable: true,
       value: {
         ethereum: provider,
+        addEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
       },
     });
 
@@ -78,6 +81,9 @@ describe('request', () => {
       writable: true,
       value: {
         ethereum: provider,
+        addEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
       },
     });
 

--- a/src/utils/snaps.test.ts
+++ b/src/utils/snaps.test.ts
@@ -122,6 +122,9 @@ describe('getMetaMaskProvider', () => {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           web3_clientVersion: 'MetaMask/11.0.0',
         }),
+        addEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
       },
     });
 
@@ -146,6 +149,9 @@ describe('getMetaMaskProvider', () => {
             provider,
           ],
         },
+        addEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
       },
     });
 
@@ -170,6 +176,9 @@ describe('getMetaMaskProvider', () => {
             provider,
           ],
         },
+        addEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
       },
     });
 
@@ -230,6 +239,9 @@ describe('getSnapsProvider', () => {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           wallet_getAllSnaps: [],
         }),
+        addEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
       },
     });
 
@@ -254,6 +266,9 @@ describe('getSnapsProvider', () => {
             provider,
           ],
         },
+        addEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
       },
     });
 
@@ -278,6 +293,9 @@ describe('getSnapsProvider', () => {
             provider,
           ],
         },
+        addEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        removeEventListener: jest.fn(),
       },
     });
 

--- a/src/utils/snaps.ts
+++ b/src/utils/snaps.ts
@@ -118,6 +118,12 @@ export async function getMetaMaskProvider() {
     return null;
   }
 
+  const eip6963Provider = await getMetaMaskEIP6963Provider();
+
+  if (eip6963Provider) {
+    return eip6963Provider;
+  }
+
   if (await isMetaMaskProvider()) {
     return window.ethereum;
   }
@@ -138,12 +144,6 @@ export async function getMetaMaskProvider() {
     }
   }
 
-  const eip6963Provider = await getMetaMaskEIP6963Provider();
-
-  if (eip6963Provider) {
-    return eip6963Provider;
-  }
-
   return null;
 }
 
@@ -156,6 +156,12 @@ export async function getMetaMaskProvider() {
 export async function getSnapsProvider() {
   if (typeof window === 'undefined') {
     return null;
+  }
+
+  const eip6963Provider = await getMetaMaskEIP6963Provider();
+
+  if (eip6963Provider && (await hasSnapsSupport(eip6963Provider))) {
+    return eip6963Provider;
   }
 
   if (await hasSnapsSupport()) {
@@ -176,12 +182,6 @@ export async function getSnapsProvider() {
         return provider;
       }
     }
-  }
-
-  const eip6963Provider = await getMetaMaskEIP6963Provider();
-
-  if (eip6963Provider && (await hasSnapsSupport(eip6963Provider))) {
-    return eip6963Provider;
   }
 
   return null;


### PR DESCRIPTION
Prefer EIP-6963 for detecting providers to reduce usage of providers pretending to be MetaMask or providers that aggressively overwrite `window.ethereum`.