### PR TITLE
Bump `brace-expansion` from `2.0.1` to `2.0.2`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8943,11 +8943,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "brace-expansion@npm:2.0.1"
+  version: 2.0.2
+  resolution: "brace-expansion@npm:2.0.2"
   dependencies:
     balanced-match: ^1.0.0
-  checksum: a61e7cd2e8a8505e9f0036b3b6108ba5e926b4b55089eeb5550cd04a471fe216c96d4fe7e4c7f995c728c554ae20ddfc4244cad10aef255e72b62930afd233d1
+  checksum: 01dff195e3646bc4b0d27b63d9bab84d2ebc06121ff5013ad6e5356daa5a9d6b60fa26cf73c74797f2dc3fbec112af13578d51f75228c1112b26c790a87b0488
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps `brace-expansion` from `2.0.1` to `2.0.2` to resolve this Dependabot alert: https://github.com/MetaMask/snaps-directory/security/dependabot/52