### PR TITLE
chore(dev-deps): Bump `ws` from `8.11.0` to `8.17.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "express": "^4.21.2",
     "path-to-regexp": "^0.1.12",
     "sharp": "^0.34.2",
+    "ws": "^8.17.1",
     "xml2js": "^0.5.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22796,9 +22796,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0":
-  version: 8.14.2
-  resolution: "ws@npm:8.14.2"
+"ws@npm:^8.17.1":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -22807,22 +22807,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 3ca0dad26e8cc6515ff392b622a1467430814c463b3368b0258e33696b1d4bed7510bc7030f7b72838b9fdeb8dbd8839cbf808367d6aae2e1d668ce741d4308b
-  languageName: node
-  linkType: hard
-
-"ws@npm:~8.11.0":
-  version: 8.11.0
-  resolution: "ws@npm:8.11.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 316b33aba32f317cd217df66dbfc5b281a2f09ff36815de222bc859e3424d83766d9eb2bd4d667de658b6ab7be151f258318fb1da812416b30be13103e5b5c67
+  checksum: d64ef1631227bd0c5fe21b3eb3646c9c91229402fb963d12d87b49af0a1ef757277083af23a5f85742bae1e520feddfb434cb882ea59249b15673c16dc3f36e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps `ws` from `8.11.0` to `8.17.1` to resolve this Dependabot alert: https://github.com/MetaMask/snaps-directory/security/dependabot/21