### PR TITLE
fix: Await `verify` function

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -138,7 +138,7 @@ async function getRegistry() {
     headers: HEADERS,
   }).then(async (response) => response.json());
 
-  const isRegistryValid = verify({
+  const isRegistryValid = await verify({
     registry: rawRegistry,
     signature,
     publicKey: PUBLIC_KEY,


### PR DESCRIPTION
After bumping `snaps-registry`, `verify` needs to be awaited.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a one-line build-time fix to correctly await `verify`, affecting only registry signature validation flow during Gatsby sourcing.
> 
> **Overview**
> Fixes registry signature validation during the Gatsby build by awaiting the now-async `verify` call before asserting validity.
> 
> This ensures the `Invalid registry signature` check uses the resolved boolean result rather than a pending Promise after the `snaps-registry` dependency update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03e05797020286176f907887d6eb608dd055f4ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->