### PR TITLE
chore: Change CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/snaps-devs
+*                                    @MetaMask/core-platform


### PR DESCRIPTION
Change CODEOWNERS to `core-platform`,

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes repository ownership metadata only; it does not affect runtime code or production behavior.
> 
> **Overview**
> Updates `.github/CODEOWNERS` so the catch-all `*` pattern is owned by `@MetaMask/core-platform` instead of the previous team.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be4a1b8d42309dad5b5f7775b4174b747a1455f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->