### PR TITLE
fix: Disable connection keepalive when using `node-fetch`

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -64,6 +64,7 @@ const PUBLIC_KEY =
 const STATS_URL = 'https://data.snaps.metamask.io/';
 
 const HEADERS = {
+  Connection: 'close',
   'User-Agent':
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36',
 };


### PR DESCRIPTION
Disable HTTP connection keepalive when using `node-fetch` to fetch the registry as it may fail with newer Node versions, when the content is gzipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-header change to build-time HTTP behavior only; no runtime app logic, auth, or data model changes.
> 
> **Overview**
> Adds **`Connection: close`** to the shared `HEADERS` object in `gatsby-node.ts` so every **`node-fetch`** call during the Gatsby build (registry, signature, cached registry, and stats) closes the TCP connection instead of reusing keep-alive pools.
> 
> This targets intermittent **registry fetch failures on newer Node versions** when persistent connections are left open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33e9924b6dd8829793a9e4122c7921ecb0353471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->